### PR TITLE
make sure that all rm operations are -f to allow consecutive cleans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,7 @@ netlink.o:	netlink.c
 		$(CC) -I. -Wall -c netlink.c
 
 clean:
-		rm -f *.o
-		rm atop atopacctd
+		rm -f *.o atop atopacctd
 
 distr:
 		rm -f *.o atop


### PR DESCRIPTION
Hi,

running make clean multiple times returns non-zero because not all rm invocations are with -f.

This trivial patch fixes that and unbreaks the Debian package build.

Please consider applying.

Greetings
Marc
