### PR TITLE
Add gitignore and remove rcsid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+atop
+atopsar
+atopacctd
+*.o
+versdate.h

--- a/acctproc.c
+++ b/acctproc.c
@@ -113,8 +113,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: acctproc.c,v 1.28 2010/04/23 12:20:19 gerlof Exp $";
-
 #define	_FILE_OFFSET_BITS	64
 
 #include <sys/types.h>

--- a/atop.c
+++ b/atop.c
@@ -271,8 +271,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: atop.c,v 1.49 2010/10/23 14:01:00 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/mman.h>

--- a/atopsar.c
+++ b/atopsar.c
@@ -29,8 +29,6 @@
 ** --------------------------------------------------------------------------
 */
 
-static const char rcsid[] = "$Id: atopsar.c,v 1.28 2010/11/26 06:19:43 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/mman.h>

--- a/deviate.c
+++ b/deviate.c
@@ -168,8 +168,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: deviate.c,v 1.45 2010/10/23 14:02:03 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/photoproc.c
+++ b/photoproc.c
@@ -136,8 +136,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: photoproc.c,v 1.33 2010/04/23 12:19:35 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <dirent.h>

--- a/photosyst.c
+++ b/photosyst.c
@@ -149,8 +149,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: photosyst.c,v 1.38 2010/11/19 07:40:40 gerlof Exp $";
-
 #include <sys/types.h>
 #include <stdio.h>
 #include <string.h>

--- a/procdbase.c
+++ b/procdbase.c
@@ -58,8 +58,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: procdbase.c,v 1.8 2010/04/23 12:19:35 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <stdio.h>

--- a/showgeneric.c
+++ b/showgeneric.c
@@ -255,8 +255,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: showgeneric.c,v 1.71 2010/10/25 19:08:32 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/showlinux.c
+++ b/showlinux.c
@@ -262,8 +262,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: showlinux.c,v 1.70 2010/10/23 14:04:12 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/showprocs.c
+++ b/showprocs.c
@@ -82,8 +82,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: showprocs.c,v 1.15 2011/09/05 11:44:16 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/showsys.c
+++ b/showsys.c
@@ -68,8 +68,6 @@
 **
 */
 
-static const char rcsid[] = "XXXXXX";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/various.c
+++ b/various.c
@@ -98,8 +98,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: various.c,v 1.21 2010/11/12 06:16:16 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>


### PR DESCRIPTION
1. Setting up `.gitignore` avoids some noise in git, making it nicer to work with.
2. `rcsid` was not used anywhere, so it led to compiler warnings. Remove it.  All the historical information is still available in the file header comments.