### PR TITLE
atopacctd: don't hang when running in a linux container (it can't succeed though)

### DIFF
--- a/atopacct.service
+++ b/atopacct.service
@@ -5,6 +5,11 @@ Conflicts=psacct.service
 After=syslog.target
 Before=atop.service
 
+# Let's skip on containers here, at least for now.
+# Currently, Linux Containers don't support process accounting
+# (and failed services are painful for Debian-style packages).
+ConditionVirtualization=!container
+
 [Service]
 Type=forking
 PIDFile=/var/run/atopacctd.pid

--- a/atopacctd.c
+++ b/atopacctd.c
@@ -364,11 +364,11 @@ main(int argc, char *argv[])
 	}
 
 	/*
- 	** create directory to store the shadow files
+	** create directory to store the shadow files
 	*/
 	snprintf(shadowdir, sizeof shadowdir, "%s/%s", pacctdir, PACCTSHADOWD);
 
-	if ( mkdir(shadowdir, 0755) == -1)
+	if ( mkdir(shadowdir, 0755) == -1 && errno != EEXIST)
        	{
 		perror(shadowdir);
 		exit(6);

--- a/netlink.c
+++ b/netlink.c
@@ -109,7 +109,7 @@ nlsock_getfam(int nlsock)
 
         if ( (len = recv(nlsock, &msg, sizeof msg, 0)) == -1)
 	{
-		perror("receive NETLINK family");
+		perror("receive NETLINK family for taskstats");
 		exit(1);
 	}
 
@@ -117,9 +117,10 @@ nlsock_getfam(int nlsock)
 	{
 		struct nlmsgerr *err = NLMSG_DATA(&msg);
 
-		fprintf(stderr, "receive NETLINK family, errno %d\n",
-                                err->error);
+		/* nlmsgerr holds a negative errno */
+		errno = -err->error;
 
+		perror("get NETLINK family for taskstats");
 		exit(1);
 	}
 

--- a/netlink.c
+++ b/netlink.c
@@ -68,6 +68,7 @@ netlink_open(void)
 		&cpudef, strlen(cpudef)+1) == -1)
 	{
 		fprintf(stderr, "register cpumask failed\n");
+		close(nlsock);
 		return -1;
 	}
 
@@ -152,6 +153,7 @@ nlsock_open(void)
 									== -1)
 	{
 		perror("set length receive buffer");
+		close(nlsock);
 		exit(1);
 	}
 


### PR DESCRIPTION
(Summary of commit messages)

This fixes a hang when running atopacctd in a systemd-nspawn container.
It now exits immediately with an error.
The error message is improved.

This is not enough to avoid unpleasantness with the Debian package, since it tries to starts atopacctd immediately (hence apt fails, leaving the package marked as "half-configured"). I'm not 100% sure what more to do, because Linux containers might implement some process accounting scheme later... but for now I've added `ConditionVirtualization=!container` to `atopacct.service`.