### PR TITLE
Include sysmacros.h to compile with newer gcc

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -152,6 +152,7 @@
 static const char rcsid[] = "$Id: photosyst.c,v 1.38 2010/11/19 07:40:40 gerlof Exp $";
 
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
Older gcc throws a warning
```
photosyst.c: In function 'lvmmapname':
photosyst.c:1465:13: warning: In the GNU C Library, "major" is defined
 by <sys/sysmacros.h>. For historical compatibility, it is
 currently defined by <sys/types.h> as well, but we plan to
 remove this soon. To use "major", include <sys/sysmacros.h>
 directly. If you did not intend to use a system-defined macro
 "major", you should undefine it after including <sys/types.h>.
     dmp->major  = major(statbuf.st_rdev);
```

Newer gcc throws an error:

```
photosyst.c: In function ‘lvmmapname’:
photosyst.c:1482:19: error: called object ‘major’ is not a function or function pointer
     dmp->major  = major(statbuf.st_rdev);
                   ^~~~~
photosyst.c:1437:25: note: declared here
 lvmmapname(unsigned int major, unsigned int minor,
            ~~~~~~~~~~~~~^~~~~
```