### PR TITLE
Fixed type mismatch in format string.

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -891,7 +891,7 @@ engine(void)
 			curpexit = malloc(nprocexit * sizeof(struct tstat));
 
 			ptrverify(curpexit,
-			          "Malloc failed for %d exited processes\n",
+			          "Malloc failed for %u exited processes\n",
 			          nprocexit);
 
 			memset(curpexit, 0, nprocexit * sizeof(struct tstat));

--- a/deviate.c
+++ b/deviate.c
@@ -243,7 +243,7 @@ deviattask(struct tstat    *curtpres, int ntaskpres,
  	devtstat->ntaskall = ntaskpres + nprocexit;
 	devtstat->taskall  = malloc(devtstat->ntaskall * sizeof(struct tstat));
 
-	ptrverify(devtstat->taskall, "Malloc failed for %d deviated tasks\n",
+	ptrverify(devtstat->taskall, "Malloc failed for %lu deviated tasks\n",
                                   devtstat->ntaskall);
 
 	/*


### PR DESCRIPTION
`nprocexit` is of type `unsigned int`, thus `%u` should be used in the format string, not `%d`.