### PR TITLE
Fixed va_list usage.

### DIFF
--- a/atopconvert.c
+++ b/atopconvert.c
@@ -1054,14 +1054,11 @@ testcompval(int rv, char *func)
 void
 ptrverify(const void *ptr, const char *errormsg, ...)
 {
-        va_list args;
-
-        va_start(args, errormsg);
-
         if (!ptr)
         {
                 va_list args;
-                fprintf(stderr, errormsg, args);
+                va_start(args, errormsg);
+                vfprintf(stderr, errormsg, args);
                 va_end  (args);
 
                 exit(13);

--- a/various.c
+++ b/various.c
@@ -560,21 +560,19 @@ getboot(void)
 void
 ptrverify(const void *ptr, const char *errormsg, ...)
 {
-	va_list args;
-
-        va_start(args, errormsg);
-
 	if (!ptr)
 	{
+		va_list args;
+
 		acctswoff();
 		netatop_signoff();
 
 		if (vis.show_end)
 			(vis.show_end)();
 
-        	va_list args;
-		fprintf(stderr, errormsg, args);
-        	va_end  (args);
+		va_start(args, errormsg);
+		vfprintf(stderr, errormsg, args);
+		va_end  (args);
 
 		exit(13);
 	}


### PR DESCRIPTION
The huge process number in the error message shown in #41 was wrong and due to incorrect usage of va_list. This patch fixes the error message (the malloc failure is another issue, due to limited locked memory, described in #41).