### PR TITLE
atop.daily, atop.init, atop-pm.sh, mkdate: Avoid using bash

### DIFF
--- a/atop-pm.sh
+++ b/atop-pm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 case "$1" in
 	pre)	/usr/bin/systemctl stop atop

--- a/atop.daily
+++ b/atop.daily
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 LOGOPTS="-R"				# default options
 LOGINTERVAL=600				# default interval in seconds
@@ -38,7 +38,7 @@ then
 
 	while ps -p `cat "$PIDFILE"` > /dev/null
 	do
-		let CNT+=1
+		CNT=$((CNT + 1))
 
 		if [ $CNT -gt 5 ]
 		then

--- a/atop.init
+++ b/atop.init
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # atop		Startup script for the Atop process logging in background
 #
@@ -47,7 +47,7 @@ case "$1" in
 
 		while ps -p `cat $PIDFILE` > /dev/null
 		do
-			let CNT+=1
+			CNT=$((CNT + 1))
 
 			if [ $CNT -gt 5 ]
 			then

--- a/mkdate
+++ b/mkdate
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Make a new versdate.h with the current date filled
 #


### PR DESCRIPTION
Avoid using bash and bashisms when not necesary. On some systems,
e.g., embedded products, bash may not be available by default.

Signed-off-by: Peter Kjellerstedt <peter.kjellerstedt@axis.com>