### PR TITLE
For systemd - replace 5 files with atop-rotate.timer

### DIFF
--- a/atop-rotate.service
+++ b/atop-rotate.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Restart atop daemon to rotate logs
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/systemctl try-restart atop.service

--- a/atop-rotate.timer
+++ b/atop-rotate.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Daily atop restart
+
+[Timer]
+OnCalendar=daily
+
+[Install]
+WantedBy=timers.target

--- a/atop.service
+++ b/atop.service
@@ -3,10 +3,8 @@ Description=Atop advanced performance monitor
 Documentation=man:atop(1)
 
 [Service]
-Type=simple
-ExecStart=/usr/share/atop/atop.daily
-KillSignal=SIGUSR2
-#ExecStopPost=/usr/bin/sleep 3
+ExecStart=/bin/sh -c 'exec /usr/bin/atop -w /var/log/atop/atop_`date +%%Y%%m%%d` 60'
+ExecStartPost=/usr/bin/find /var/log/atop -name "atop_*" -mtime +28 -exec rm -v {} \;
 
 [Install]
 WantedBy=multi-user.target

--- a/atop.service
+++ b/atop.service
@@ -3,8 +3,15 @@ Description=Atop advanced performance monitor
 Documentation=man:atop(1)
 
 [Service]
-ExecStart=/bin/sh -c 'exec /usr/bin/atop -w /var/log/atop/atop_`date +%%Y%%m%%d` 60'
-ExecStartPost=/usr/bin/find /var/log/atop -name "atop_*" -mtime +28 -exec rm -v {} \;
+Environment=LOGOPTS="-R"
+Environment=LOGINTERVAL=600
+Environment=LOGGENERATIONS=28
+Environment=LOGPATH=/var/log/atop
+EnvironmentFile=/etc/default/atop
+ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGINTERVAL" -eq "$LOGINTERVAL"'
+ExecStartPre=/bin/sh -c 'test -n "$LOGGENERATIONS" -a "$LOGGENERATIONS" -eq "$LOGGENERATIONS"'
+ExecStart=/bin/sh -c 'exec /usr/bin/atop ${LOGOPTS} -w "${LOGPATH}/atop_$(date +%%Y%%m%%d)" ${LOGINTERVAL}'
+ExecStartPost=/usr/bin/find "${LOGPATH}" -name "atop_*" -mtime +${LOGGENERATIONS} -exec rm -v {} \;
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This expands on #38 to show what actually improves - this removes the need for `/etc/cron.d/atop`, `/etc/logrotate.d/psaccs_atop`, `/etc/logrotate.d/psaccu_atop`, `/usr/share/atop/atop.daily`, `/var/log/atop/dummy_after` and `/var/log/atop/dummy_before` on systemd systems and replace it with `atop-rotate.service` / `.timer` instead.

If users want to customize what was previously in the LOG* constants - they can use systemd drop-in units to overload the service