### PR TITLE
Fix unchecked opendir to prevent dereferencing a NULL pointer

### DIFF
--- a/photoproc.c
+++ b/photoproc.c
@@ -311,6 +311,12 @@ photoproc(struct tstat *tasklist, int maxtask)
 			{
 				dirtask = opendir(".");
 	
+				if( dirtask == NULL )		
+				{
+					if(chdir("../..") == -1);  /* leave task and process-level directories */
+					continue;
+				}
+
 				while ((tent=readdir(dirtask)) && tval<maxtask)
 				{
 					struct tstat *curthr = tasklist+tval;


### PR DESCRIPTION
A race condition exists where a task can exit after the opendir(task) resulting in a segfault.  This is tested and fixed in my environment of 10k+ systems