### PR TITLE
Make LOGPATH overrulable

### DIFF
--- a/atop.daily
+++ b/atop.daily
@@ -3,6 +3,7 @@
 LOGOPTS="-R"				# default options
 LOGINTERVAL=600				# default interval in seconds
 LOGGENERATIONS=28			# default number of days
+LOGPATH=/var/log/atop                   # default log location
 
 # allow administrator to overrule the variables
 # defined above
@@ -24,7 +25,6 @@ then
 fi
 
 CURDAY=`date +%Y%m%d`
-LOGPATH=/var/log/atop
 BINPATH=/usr/bin
 PIDFILE=/var/run/atop.pid
 


### PR DESCRIPTION
Moved LOGPATH declaration to before DEFAULTSFILE source, so it can be overruled