### PR TITLE
Auto detect hypervisor and apply to perfevents

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -391,6 +391,7 @@ void do_swoutcritsec(char *, char *);
 void do_almostcrit(char *, char *);
 void do_atopsarflags(char *, char *);
 void do_pacctdir(char *, char *);
+void do_perfevents(char *, char *);
 
 static struct {
 	char	*tag;
@@ -438,6 +439,7 @@ static struct {
 	{	"swoutcritsec",		do_swoutcritsec,	0, },
 	{	"almostcrit",		do_almostcrit,		0, },
 	{	"atopsarflags",		do_atopsarflags,	0, },
+	{	"perfevents",		do_perfevents,		0, },
 	{	"pacctdir",		do_pacctdir,		1, },
 };
 

--- a/photosyst.c
+++ b/photosyst.c
@@ -194,7 +194,34 @@ static const char rcsid[] = "$Id: photosyst.c,v 1.38 2010/11/19 07:40:40 gerlof 
 #define	MDDTYPE	2
 #define	LVMTYPE	3
 
+/* hypervisor enum */
+enum {
+	HYPER_NONE	= 0,
+	HYPER_XEN,
+	HYPER_KVM,
+	HYPER_MSHV,
+	HYPER_VMWARE,
+	HYPER_IBM,
+	HYPER_VSERVER,
+	HYPER_UML,
+	HYPER_INNOTEK,
+	HYPER_HITACHI,
+	HYPER_PARALLELS,
+	HYPER_VBOX,
+	HYPER_OS400,
+	HYPER_PHYP,
+	HYPER_SPAR,
+	HYPER_WSL,
+};
+
 #ifndef	NOPERFEVENT
+enum {
+	PERF_EVENTS_AUTO = 0,
+	PERF_EVENTS_ENABLE,
+	PERF_EVENTS_DISABLE,
+};
+
+static int perfevents = PERF_EVENTS_AUTO;
 static void	getperfevents(struct cpustat *);
 #endif
 
@@ -202,6 +229,8 @@ static int	get_infiniband(struct ifbstat *);
 
 static int	isdisk(unsigned int, unsigned int,
 			char *, struct perdsk *, int);
+
+static int run_in_guest(void);
 
 static struct ipv6_stats	ipv6_tmp;
 static struct icmpv6_stats	icmpv6_tmp;
@@ -2056,6 +2085,31 @@ ibstat(struct ibcachent *ibc, struct perifb *ifb)
 ** 	instructions and cycles per CPU
 */
 #ifndef	NOPERFEVENT
+
+void
+do_perfevents(char *tagname, char *tagvalue)
+{
+	if (!strcmp("enable", tagvalue))
+		perfevents = PERF_EVENTS_ENABLE;
+	else if (!strcmp("disable", tagvalue))
+		perfevents = PERF_EVENTS_DISABLE;
+	else
+	{
+		if (run_in_guest())
+			perfevents = PERF_EVENTS_DISABLE;
+		else
+			perfevents = PERF_EVENTS_ENABLE;
+	}
+}
+
+static int enable_perfevents()
+{
+	if (perfevents == PERF_EVENTS_AUTO)
+		do_perfevents("perfevents", "auto");
+
+	return perfevents == PERF_EVENTS_ENABLE;
+}
+
 long
 perf_event_open(struct perf_event_attr *hwevent, pid_t pid,
                 int cpu, int groupfd, unsigned long flags)
@@ -2069,6 +2123,8 @@ getperfevents(struct cpustat *cs)
 	static int	firstcall = 1, cpualloced, *fdi, *fdc;
 	int		i;
 
+	if (!enable_perfevents())
+		return;
 	/*
  	** once initialize perf event counter retrieval
 	*/
@@ -2157,6 +2213,13 @@ getperfevents(struct cpustat *cs)
                         cs->all.cycle += cs->cpu[i].cycle;
 		}
         }
+}
+#else
+void
+do_perfevents(char *tagname, char *tagvalue)
+{
+	perror("this binary is built with NOPERFEVENT, can not use perfevents");
+	cleanstop(1);
 }
 #endif
 
@@ -2275,3 +2338,70 @@ getwwwstat(unsigned short port, struct wwwstat *wp)
 	return 1;
 }
 #endif
+
+#if defined(__x86_64__) || defined(__i386__)
+#define HYPERVISOR_INFO_LEAF   0x40000000
+
+static inline void
+x86_cpuid(unsigned int op, unsigned int *eax, unsigned int *ebx,
+			 unsigned int *ecx, unsigned int *edx)
+{
+	__asm__(
+#if defined(__PIC__) && defined(__i386__)
+		"xchg %%ebx, %%esi;"
+		"cpuid;"
+		"xchg %%esi, %%ebx;"
+		: "=S" (*ebx),
+#else
+		"cpuid;"
+		: "=b" (*ebx),
+#endif
+		  "=a" (*eax),
+		  "=c" (*ecx),
+		  "=d" (*edx)
+		: "1" (op), "c"(0));
+}
+
+static int
+get_hypervisor(void)
+{
+	unsigned int eax = 0, ebx = 0, ecx = 0, edx = 0, hyper = HYPER_NONE;
+	char hyper_vendor_id[13];
+
+	memset(hyper_vendor_id, 0, sizeof(hyper_vendor_id));
+
+	x86_cpuid(HYPERVISOR_INFO_LEAF, &eax, &ebx, &ecx, &edx);
+	memcpy(hyper_vendor_id + 0, &ebx, 4);
+	memcpy(hyper_vendor_id + 4, &ecx, 4);
+	memcpy(hyper_vendor_id + 8, &edx, 4);
+	hyper_vendor_id[12] = '\0';
+
+	if (!hyper_vendor_id[0])
+		return hyper;
+
+	if (!strncmp("XenVMMXenVMM", hyper_vendor_id, 12))
+		hyper = HYPER_XEN;
+	else if (!strncmp("KVMKVMKVM", hyper_vendor_id, 9))
+		hyper = HYPER_KVM;
+	else if (!strncmp("Microsoft Hv", hyper_vendor_id, 12))
+		hyper = HYPER_MSHV;
+	else if (!strncmp("VMwareVMware", hyper_vendor_id, 12))
+		hyper = HYPER_VMWARE;
+	else if (!strncmp("UnisysSpar64", hyper_vendor_id, 12))
+		hyper = HYPER_SPAR;
+
+	return hyper;
+}
+#else /* ! (__x86_64__ || __i386__) */
+static int
+get_hypervisor(void)
+{
+	return HYPER_NONE;
+}
+#endif
+
+static int
+run_in_guest(void)
+{
+	return get_hypervisor() != HYPER_NONE;
+}


### PR DESCRIPTION
In virtualization case, PMU in guest is emulated by hypervisor, such as
vPMU is emulated by KVM.
Currently perf in guest has overhead, typically rdpmc/wrmsr cause a lot
of vm-exits, and guest will hit a performance drop. atop should be
careful while useing perf.

Support "perfevents" config in atoprc, which supports 3 modes:
"enable": force using perf.
"disable": force disable perf.
"auto": default mode, atop will detect hypervisor. if atop is running in
guest, auto disable perf, otherwise enable perf.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>