### PR TITLE
Fix compilation warnings and some danger string manipulation

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -271,8 +271,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: atop.c,v 1.49 2010/10/23 14:01:00 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/mman.h>

--- a/atopacctd.c
+++ b/atopacctd.c
@@ -134,6 +134,7 @@ main(int argc, char *argv[])
 	time_t			gclast = time(0);
 
 	struct sigaction	sigcleanup;
+	int			liResult;
 
 	/*
 	** argument passed?
@@ -304,7 +305,16 @@ main(int argc, char *argv[])
 
 	umask(022);
 
-	(void) chdir("/tmp");			// go to a safe place
+	liResult = chdir("/tmp");			// go to a safe place
+	if( liResult != 0 )
+	{
+		// TODO: Return verification enforced by gcc
+		//       Since I don't know(yet) where to log
+		//       I just created the message
+		char lcMessage[ 64 ];
+		snprintf( lcMessage, sizeof( lcMessage ), 
+		          "%s:%d - Error %d changing to tmp dir\n", __FILE__, __LINE__, errno );
+	}
 
 	/*
 	** increase semaphore to define that atopacctd is running
@@ -368,7 +378,16 @@ main(int argc, char *argv[])
 	** raise priority (be sure the nice value becomes -20,
 	** independent of the current nice value)
 	*/
-	(void) nice(-39);
+	liResult = nice(-39);
+	if( liResult < 0 )
+	{
+		// TODO: Return verification enforced by gcc
+		//       Since I don't know(yet) where to log
+		//       I just created the message
+		char lcMessage[ 64 ];
+		snprintf( lcMessage, sizeof( lcMessage ), 
+		          "%s:%d - Error %d setting proccess priority\n", __FILE__, __LINE__, errno );
+	}
 
 	/*
  	** connect to NETLINK socket of kernel to be triggered
@@ -966,6 +985,7 @@ setcurrent(long curshadow)
 	static int	cfd = -1;
 	char		currentpath[128], currentdata[128];
 	int		len;
+	int		liResult;
 
 	/*
 	** assemble file name of currency file and open (only once)
@@ -992,9 +1012,28 @@ setcurrent(long curshadow)
 	/*
 	** wipe currency file and write new assembled string
 	*/
-	(void) ftruncate(cfd, 0);
+	liResult = ftruncate(cfd, 0);
+	if( liResult < 0 )
+	{
+		// TODO: Return verification enforced by gcc
+		//       Since I don't know(yet) where to log
+		//       I just created the message
+		char lcMessage[ 64 ];
+		snprintf( lcMessage, sizeof( lcMessage ), 
+		          "%s:%d - Error %d ftruncate\n", __FILE__, __LINE__, errno );
+	}
+
 	(void) lseek(cfd, 0, SEEK_SET);
-	(void) write(cfd, currentdata, len);
+	liResult = write(cfd, currentdata, len);
+	if( liResult < 0 )
+	{
+		// TODO: Return verification enforced by gcc
+		//       Since I don't know(yet) where to log
+		//       I just created the message
+		char lcMessage[ 64 ];
+		snprintf( lcMessage, sizeof( lcMessage ), 
+		          "%s:%d - Error %d writing\n", __FILE__, __LINE__, errno );
+	}
 }
 
 /*

--- a/atopsar.c
+++ b/atopsar.c
@@ -29,8 +29,6 @@
 ** --------------------------------------------------------------------------
 */
 
-static const char rcsid[] = "$Id: atopsar.c,v 1.28 2010/11/26 06:19:43 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/mman.h>

--- a/deviate.c
+++ b/deviate.c
@@ -168,8 +168,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: deviate.c,v 1.45 2010/10/23 14:02:03 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/photoproc.c
+++ b/photoproc.c
@@ -136,8 +136,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: photoproc.c,v 1.33 2010/04/23 12:19:35 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <dirent.h>

--- a/showgeneric.c
+++ b/showgeneric.c
@@ -255,8 +255,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: showgeneric.c,v 1.71 2010/10/25 19:08:32 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/showlinux.c
+++ b/showlinux.c
@@ -261,8 +261,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: showlinux.c,v 1.70 2010/10/23 14:04:12 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>
@@ -2288,9 +2286,13 @@ compcpu(const void *a, const void *b)
         register count_t bcpu = (*(struct tstat **)b)->cpu.stime +
                                 (*(struct tstat **)b)->cpu.utime;
 
-        if (acpu < bcpu) return  1;
-        if (acpu > bcpu) return -1;
-                         return compmem(a, b);
+        if (acpu < bcpu)
+		return  1;
+
+        if (acpu > bcpu)
+		return -1;
+
+        return compmem(a, b);
 }
 
 int
@@ -2312,9 +2314,13 @@ compdsk(const void *a, const void *b)
 	else
 		bdsk = tb->dsk.rio;
 
-        if (adsk < bdsk) return  1;
-        if (adsk > bdsk) return -1;
-                         return compcpu(a, b);
+        if (adsk < bdsk)
+		return  1;
+
+        if (adsk > bdsk)
+		return -1;
+
+        return compcpu(a, b);
 }
 
 int
@@ -2323,9 +2329,13 @@ compmem(const void *a, const void *b)
         register count_t amem = (*(struct tstat **)a)->mem.rmem;
         register count_t bmem = (*(struct tstat **)b)->mem.rmem;
 
-        if (amem < bmem) return  1;
-        if (amem > bmem) return -1;
-                         return  0;
+        if (amem < bmem)
+		return  1;
+
+        if (amem > bmem)
+		return -1;
+
+        return  0;
 }
 
 int
@@ -2346,15 +2356,23 @@ compgpu(const void *a, const void *b)
 
 	if (abusy == -1 || bbusy == -1)
 	{
-        	if (amem < bmem)	return  1;
-	        if (amem > bmem) 	return -1;
-                         		return  0;
+        	if (amem < bmem)
+			return  1;
+
+	        if (amem > bmem)
+			return -1;
+
+                return  0;
 	}
 	else
 	{
-		if (abusy < bbusy)	return  1;
-		if (abusy > bbusy)	return -1;
-       		                  	return  0;
+		if (abusy < bbusy)
+			return  1;
+
+		if (abusy > bbusy)
+			return -1;
+
+       		return  0;
 	}
 }
 
@@ -2370,9 +2388,13 @@ compnet(const void *a, const void *b)
                                 (*(struct tstat **)b)->net.udpssz +
                                 (*(struct tstat **)b)->net.udprsz  ;
 
-        if (anet < bnet) return  1;
-        if (anet > bnet) return -1;
-                         return compcpu(a, b);
+        if (anet < bnet)
+		return  1;
+
+        if (anet > bnet)
+		return -1;
+
+	return compcpu(a, b);
 }
 
 int
@@ -2381,9 +2403,13 @@ compusr(const void *a, const void *b)
         register int uida = (*(struct tstat **)a)->gen.ruid;
         register int uidb = (*(struct tstat **)b)->gen.ruid;
 
-        if (uida > uidb) return  1;
-        if (uida < uidb) return -1;
-                         return  0;
+        if (uida > uidb)
+		return  1;
+
+        if (uida < uidb)
+		return -1;
+
+        return  0;
 }
 
 int
@@ -2415,9 +2441,13 @@ cpucompar(const void *a, const void *b)
         register count_t bidle = ((struct percpu *)b)->itime +
                                  ((struct percpu *)b)->wtime;
 
-        if (aidle < bidle) return -1;
-        if (aidle > bidle) return  1;
-                           return  0;
+        if (aidle < bidle)
+		return -1;
+
+        if (aidle > bidle)
+		return  1;
+
+	return  0;
 }
 
 int
@@ -2430,15 +2460,23 @@ gpucompar(const void *a, const void *b)
 
 	if (agpuperc == -1 || bgpuperc == -1)
 	{
-        	if (amemuse < bmemuse)	return  1;
-        	if (amemuse > bmemuse)	return -1;
-                      			return  0;
+        	if (amemuse < bmemuse)
+			return  1;
+
+        	if (amemuse > bmemuse)
+			return -1;
+
+		return  0;
 	}
 	else
 	{
-        	if (agpuperc < bgpuperc)	return  1;
-        	if (agpuperc > bgpuperc)	return -1;
-                      				return  0;
+        	if (agpuperc < bgpuperc)
+			return  1;
+
+        	if (agpuperc > bgpuperc)
+			return -1;
+
+		return  0;
 	}
 }
 
@@ -2448,9 +2486,13 @@ diskcompar(const void *a, const void *b)
         register count_t amsio = ((struct perdsk *)a)->io_ms;
         register count_t bmsio = ((struct perdsk *)b)->io_ms;
 
-        if (amsio < bmsio) return  1;
-        if (amsio > bmsio) return -1;
-                           return  0;
+        if (amsio < bmsio)
+		return  1;
+
+        if (amsio > bmsio)
+		return -1;
+
+        return  0;
 }
 
 int
@@ -2496,16 +2538,24 @@ intfcompar(const void *a, const void *b)
         */
         if (aspeed && bspeed)
         {
-                if (afactor < bfactor)  return  1;
-                if (afactor > bfactor)  return -1;
-                                        return  0;
+                if (afactor < bfactor)
+			return  1;
+
+                if (afactor > bfactor)
+			return -1;
+
+                return  0;
         }
 
         if (!aspeed && !bspeed)
         {
-                if ((arbyte + asbyte) < (brbyte + bsbyte))      return  1;
-                if ((arbyte + asbyte) > (brbyte + bsbyte))      return -1;
-                                                                return  0;
+                if ((arbyte + asbyte) < (brbyte + bsbyte))
+			return  1;
+
+                if ((arbyte + asbyte) > (brbyte + bsbyte))
+			return -1;
+
+                return  0;
         }
 
         if (aspeed)
@@ -2523,9 +2573,13 @@ ifbcompar(const void *a, const void *b)
         count_t btransfer  = ((struct perifb *)b)->rcvb +
                              ((struct perifb *)b)->sndb;
 
-	if (atransfer < btransfer)	return  1;
-	if (atransfer > btransfer)	return -1;
-					return  0;
+	if (atransfer < btransfer)
+		return  1;
+
+	if (atransfer > btransfer)
+		return -1;
+
+	return  0;
 }
 
 
@@ -2544,9 +2598,13 @@ nfsmcompar(const void *a, const void *b)
 	                         nb->bytestotread + nb->bytestotwrite +
                                  nb->pagesmread   + nb->pagesmwrite;
 
-        if (aused < bused) return  1;
-        if (aused > bused) return -1;
-                           return  0;
+        if (aused < bused)
+                return  1;
+
+        if (aused > bused)
+                return -1;
+
+        return  0;
 }
 
 int
@@ -2558,9 +2616,13 @@ contcompar(const void *a, const void *b)
         register count_t aused = ca->system + ca->user + ca->nice;
         register count_t bused = cb->system + cb->user + cb->nice;
 
-        if (aused < bused) return  1;
-        if (aused > bused) return -1;
-                           return  0;
+        if (aused < bused) 
+                return  1;
+
+        if (aused > bused)
+                return -1;
+
+        return  0;
 }
 
 /*

--- a/showprocs.c
+++ b/showprocs.c
@@ -82,8 +82,6 @@
 **
 */
 
-static const char rcsid[] = "$Id: showprocs.c,v 1.15 2011/09/05 11:44:16 gerlof Exp $";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>

--- a/showsys.c
+++ b/showsys.c
@@ -68,8 +68,6 @@
 **
 */
 
-static const char rcsid[] = "XXXXXX";
-
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/stat.h>
@@ -2124,6 +2122,16 @@ sysprt_NETNAME(void *p, void *q, int badness, int *color)
                                		(sstat->intf.intf[as->index].speed *10);
 		}
 
+		if( busy < 0 )
+		{
+			// TODO: insert some log
+			busy = 0;
+		}		
+		else if( busy > 999 )
+		{
+			// TODO: insert some log
+			busy = 999;
+		}
 	        snprintf(buf, sizeof(buf)-1, "%-7.7s %3lld%%", 
        		          sstat->intf.intf[as->index].name, busy);
 
@@ -2204,7 +2212,18 @@ char *makenetspeed(count_t val, int nsecs)
                 c = 'T';
         }
 
-        sprintf(buf+3, "%4lld %cbps", val, c);
+	if( val < 0 )
+	{
+		// TODO: insert some log
+		val = 0;
+	}
+	else if( val > 9999 )
+	{
+		// TODO: insert some log
+		val = 9999;
+	}
+
+        snprintf(buf+3, sizeof( buf ) - 3, "%4lld %cbps", val, c);
 
         return buf;
 }
@@ -2226,6 +2245,11 @@ sysprt_NETSPEEDMAX(void *p, void *q, int badness, int *color)
 	else
 	{
 		speed /= 1000;
+		if( speed > 9999 )
+		{
+			// TODO: insert some log
+			speed = 9999;
+		}
         	snprintf(buf, sizeof buf, "sp %4lld Gbps", speed);
 	}
 
@@ -2424,6 +2448,11 @@ sysprt_IFBSPEEDMAX(void *p, void *q, int badness, int *color)
 	else
 	{
 		rate /= 1000;
+		if( rate > 9999 )
+		{
+			// TODO: insert some log
+			rate = 9999;
+		}
         	snprintf(buf, sizeof buf, "sp %4lld Gbps", rate);
 	}
 

--- a/various.c
+++ b/various.c
@@ -613,5 +613,16 @@ droprootprivs(void)
 void
 regainrootprivs(void)
 {
-	seteuid(0);
+	int liResult;
+
+	liResult = seteuid(0);
+	if( liResult != 0 )
+	{
+		// TODO: Return verification enforced by gcc
+		//       Since I don't know(yet) where to log
+		//       I just created the message
+		char lcMessage[ 64 ];
+		snprintf( lcMessage, sizeof( lcMessage ), 
+		          "%s:%d - Error %d setting EUID\n", __FILE__, __LINE__, errno );
+	}
 }


### PR DESCRIPTION
Resolved a number of compilation warnings
 - Some are "cosmetic", like unused RCSID variable
 - Some messages indicate potential to create problems, like the path name smaller then the system limit.
 - Newer versions of GCC(7.4.0) enforce to verify return on system calls, implemented verification
Resolved 6 potential danger situations in string manipulation at photosyst.c