### PR TITLE
Fixed rounding problems in the average-per-second mode.

### DIFF
--- a/atop.h
+++ b/atop.h
@@ -28,13 +28,18 @@
 /*
 ** memory-size formatting possibilities
 */
-#define	ANYFORMAT	0
-#define	KBFORMAT	1
-#define	MBFORMAT	2
-#define	GBFORMAT	3
-#define	TBFORMAT	4
-#define	PBFORMAT	5
-#define	OVFORMAT	9
+#define	BFORMAT			0
+#define	KBFORMAT		1
+#define	KBFORMAT_INT	2
+#define	MBFORMAT		3
+#define	MBFORMAT_INT	4
+#define	GBFORMAT		5
+#define	GBFORMAT_INT	6
+#define	TBFORMAT		7
+#define	TBFORMAT_INT	8
+#define	PBFORMAT		9
+#define	PBFORMAT_INT	10
+#define	OVFORMAT		11
 
 typedef	long long	count_t;
 

--- a/showprocs.c
+++ b/showprocs.c
@@ -616,7 +616,7 @@ procprt_VGROW_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.vgrow*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.vgrow*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -634,7 +634,7 @@ procprt_RGROW_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.rgrow*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.rgrow*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -676,7 +676,7 @@ procprt_VSTEXT_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.vexec*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.vexec*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -694,7 +694,7 @@ procprt_VSIZE_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.vmem*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.vmem*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -712,7 +712,7 @@ procprt_RSIZE_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.rmem*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.rmem*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -733,7 +733,7 @@ procprt_PSIZE_a(struct tstat *curstat, int avgval, int nsecs)
 	if (curstat->mem.pmem == (unsigned long long)-1LL)	
         	return "    ?K";
 
-       	val2memstr(curstat->mem.pmem*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.pmem*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -751,7 +751,7 @@ procprt_VSLIBS_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.vlibs*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.vlibs*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -769,7 +769,7 @@ procprt_VDATA_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.vdata*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.vdata*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -787,7 +787,7 @@ procprt_VSTACK_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.vstack*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.vstack*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -805,7 +805,7 @@ procprt_SWAPSZ_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->mem.vswap*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->mem.vswap*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -1451,7 +1451,7 @@ char *
 procprt_RDDSK_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
-        val2memstr(curstat->dsk.rsz*512, buf, KBFORMAT, avgval, nsecs);
+        val2memstr(curstat->dsk.rsz*512, buf, BFORMAT, avgval, nsecs);
 
         return buf;
 }
@@ -1470,7 +1470,7 @@ procprt_WRDSK_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
 
-        val2memstr(curstat->dsk.wsz*512, buf, KBFORMAT, avgval, nsecs);
+        val2memstr(curstat->dsk.wsz*512, buf, BFORMAT, avgval, nsecs);
 
         return buf;
 }
@@ -1495,7 +1495,7 @@ procprt_CWRDSK_a(struct tstat *curstat, int avgval, int nsecs)
 	else
 		nett_wsz = 0;
 
-        val2memstr(nett_wsz*512, buf, KBFORMAT, avgval, nsecs);
+        val2memstr(nett_wsz*512, buf, BFORMAT, avgval, nsecs);
 
         return buf;
 }
@@ -1507,7 +1507,7 @@ char *
 procprt_WCANCEL_a(struct tstat *curstat, int avgval, int nsecs)
 {
         static char buf[10];
-        val2memstr(curstat->dsk.cwsz*512, buf, KBFORMAT, avgval, nsecs);
+        val2memstr(curstat->dsk.cwsz*512, buf, BFORMAT, avgval, nsecs);
 
         return buf;
 }
@@ -1955,7 +1955,7 @@ procprt_GPUMEMNOW_ae(struct tstat *curstat, int avgval, int nsecs)
 	if (!curstat->gpu.state)
 		return "     -";
 
-        val2memstr(curstat->gpu.memnow*1024, buf, KBFORMAT, 0, 0);
+        val2memstr(curstat->gpu.memnow*1024, buf, BFORMAT, 0, 0);
         return buf;
 }
 
@@ -1974,7 +1974,7 @@ procprt_GPUMEMAVG_ae(struct tstat *curstat, int avgval, int nsecs)
 		return("    0K");
 
        	val2memstr(curstat->gpu.nrgpus * curstat->gpu.memcum /
-	           curstat->gpu.sample*1024, buf, KBFORMAT, 0, 0);
+	           curstat->gpu.sample*1024, buf, BFORMAT, 0, 0);
        	return buf;
 }
 


### PR DESCRIPTION
Problems:
- In the average-per-second mode WRDSK,RDDSK sometimes displayed as 0.0**G/s** 0.0**M/s**. But the actual value at this moment **!= 0**.  
- Rounding is not accurate 
- In the average-per-second mode speed <1K/s displayed as '0K/s'

**Steps to reproduce:** 
- prepare a big file
`dd if=/dev/urandom of=2G.bin bs=1M count=2048`
- run atop
- atop: press '1' (for the average per second mode)
- atop: press '/' , type 'rsync', press [Enter]
- open a new shell to the same host and copy this file with speed limit
`rsync -P 2G.bin 2G-copy.bin --bwlimit=45000`
- check atop RDDISK and WRDISK for the rsync process

**Expected results:** 
atop shows the same speed as rsync (~43-44 MB/s)

**Actual results:** 
atop shows '**0.0G/s**'

Solution:
- more accurate rounding (llround) when calculating values for 1/s intervals, and while converting to KB MB GB ..
- values<=9 are displayed as before as float ex.:1.1M/s, 3.3G/s
- values 10-999 are displayed as int (llround) ex.:123M/s, 999M/s

Default units in the process view changed to Bytes (was KBytes). A little more more accurate with small values. 