### PR TITLE
Check that rawlog is seekable to prevent later segfaults

### DIFF
--- a/rawlog.c
+++ b/rawlog.c
@@ -464,6 +464,23 @@ rawread(void)
 	}
 
 	/*
+	** make sure the file is regular (because we are going to seek in it)
+	*/
+	struct stat statbuf;
+	if( stat(rawname, &statbuf) == -1)
+	{
+		fprintf(stderr, "%s - ", rawname);
+		perror("stat raw file");
+		cleanstop(7);
+	}
+
+	if( ! S_ISREG(statbuf.st_mode) )
+	{
+		fprintf(stderr, "raw file must be a regular, seekable file\n");
+		cleanstop(7);
+	}
+
+	/*
 	** open raw file
 	*/
 	if ( (rawfd = open(rawname, O_RDONLY)) == -1)


### PR DESCRIPTION
If a user does something like:

``` atop - r <(gunzip atop_2019_06_10.gz) ```

(for example), lseek() will fail to seek on the named pipe and result in a segfault.
Instead, we can check early on whether the file is a regular file and exit cleanstop() with an explanation/error.