### PR TITLE
Add support ATOPACCTDIR env variable

### DIFF
--- a/man/atop.1
+++ b/man/atop.1
@@ -223,6 +223,10 @@ will never read more than 50 MiB with process information from the
 process accounting file per interval (approx. 70000 finished processes).
 In interactive mode a warning is given whenever processes have been skipped
 for this reason.
+
+When the environment variable ATOPACCTDIR set and not empty, it specifies directory for process accounting file instead of 
+.I /var/cache/atop.d
+which set by default.
 .PP
 .SH COLORS
 For the resource consumption on system level,


### PR DESCRIPTION
Now we can set custom process accounting directory via env
variable ATOPACCTDIR instead of ACCTDIR constant.

atop.acct file can be really huge if we have many processes per server.

As example on openvz node it could be
```
-rw------- 1 root root 4.2G Jul  8 17:39 atop.acct
```
and bigger.
 And usual  `/` partition not big, but `/vz/` big and it would be great,  to have opportunity create it on another partition, without rebuild all atop with changed ACCTDIR to custom.
