### PR TITLE
Readahead rawlog to make -b operation faster

### DIFF
--- a/rawlog.c
+++ b/rawlog.c
@@ -69,6 +69,8 @@
 ** etcetera .....
 */
 #define	MYMAGIC		(unsigned int) 0xfeedbeef
+#define READAHEADOFF	22
+#define READAHEADSIZE	(1 << READAHEADOFF)
 
 struct rawheader {
 	unsigned int	magic;
@@ -514,6 +516,10 @@ rawread(void)
 		}
 	}
 
+	/* make the kernel readahead more effective, */
+	if (isregular)
+		posix_fadvise(rawfd, 0, 0, POSIX_FADV_SEQUENTIAL);
+
 	/*
 	** read the raw header and verify the magic
 	*/
@@ -644,8 +650,22 @@ rawread(void)
 						
 				if (isregular)
 				{
-					lseek(rawfd, rr.scomplen+rr.pcomplen,
-								SEEK_CUR);
+					static off_t curr_pos = -1;
+					off_t next_pos;
+
+					lastcmd = 1;
+					next_pos = lseek(rawfd, rr.scomplen+rr.pcomplen, SEEK_CUR);
+					if ((curr_pos >> READAHEADOFF) != (next_pos >> READAHEADOFF))
+					{
+						/* just read READAHEADSIZE bytes into page cache */
+						char *buf = malloc(READAHEADSIZE);
+						ptrverify(buf, "Malloc failed for readahead");
+						pread(rawfd, buf, READAHEADSIZE,
+							next_pos & ~(READAHEADSIZE - 1));
+						free(buf);
+					}
+					curr_pos = next_pos;
+					continue;
 				}
 				else	// named pipe not seekable
 				{


### PR DESCRIPTION
1, use posix_fadvise POSIX_FADV_SEQUENTIAL to double kernel readahead buffer.
2, HDD typically has a 100~200 IOPS, atop needs to read raw records more fastly
under low IOPS. So use pread syscall to load a large area(default every 4M) in
page-cache.

Test env:
set disk iops as 200 for a virtual machine(KVM).
 virsh blkdeviotune stretch sdb --write-iops-sec 200 --read-iops-sec 200 --live

Test cases:
1, test upstream atop without any page cache
	~# vmtouch -e /var/log/atop/atop_20190916
	~# time /root/atop-upstream -r /var/log/atop/atop_20190916 -b 18:00
	real	0m54.639s
	user	0m0.094s
	sys	0m0.321s

2, test upstream atop with full page cache
	~# vmtouch -t /var/log/atop/atop_20190916
	~# time /root/atop-upstream -r /var/log/atop/atop_20190916 -b 18:00
	real	0m1.266s
	user	0m0.004s
	sys	0m0.021s

3, test new atop without any page cache
	~# vmtouch -e /var/log/atop/atop_20190916
	~# time /root/atop-new -r /var/log/atop/atop_20190916 -b 18:00
	real	0m3.818s
	user	0m0.023s
	sys	0m0.170s

case 1 & case 2: speed of reading rawlog effects atop performance a lot.
case 1 & case 3: readahead makes performance better.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>