### PR TITLE
photosyst.c: fix possible error in reading InfiniBand states

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -1955,48 +1955,52 @@ ibprep(struct ibcachent *ibc)
 		{
 			(void) sscanf(linebuf, "%lld %c%*s (%hdX",
 				&(ibc->rate), &speedunit, &(ibc->lanes));
+
+            // calculate megabits/second
+            switch (speedunit)
+            {
+               case 'M':
+               case 'm':
+                break;
+               case 'G':
+               case 'g':
+                ibc->rate *= 1000;
+                break;
+               case 'T':
+               case 't':
+                ibc->rate *= 1000000;
+                break;
+            }
+
+            // build all pathnames to obtain the counters
+            // of this port later on
+            snprintf(path, sizeof path,
+                     "%s/ports/%d/counters/port_rcv_data",
+                     ibc->ibha, ibc->port);
+            ibc->pathrcvb = malloc( strlen(path)+1 );
+            strcpy(ibc->pathrcvb, path);
+
+            snprintf(path, sizeof path,
+                     "%s/ports/%d/counters/port_xmit_data",
+                     ibc->ibha, ibc->port);
+            ibc->pathsndb = malloc( strlen(path)+1 );
+            strcpy(ibc->pathsndb, path);
+
+            snprintf(path, sizeof path,
+                     "%s/ports/%d/counters/port_rcv_packets",
+                     ibc->ibha, ibc->port);
+            ibc->pathrcvp = malloc( strlen(path)+1 );
+            strcpy(ibc->pathrcvp, path);
+
+            snprintf(path, sizeof path,
+                     "%s/ports/%d/counters/port_xmit_packets",
+                     ibc->ibha, ibc->port);
+            ibc->pathsndp = malloc( strlen(path)+1 );
+            strcpy(ibc->pathsndp, path);
 		}
 
 		fclose(fp);
 	}
-
-	// calculate megabits/second
-	switch (speedunit)
-	{
-	   case 'M':
-	   case 'm':
-		break;
-	   case 'G':
-	   case 'g':
-		ibc->rate *= 1000;
-		break;
-	   case 'T':
-	   case 't':
-		ibc->rate *= 1000000;
-		break;
-	}
-
-	// build all pathnames to obtain the counters
-	// of this port later on
-	snprintf(path, sizeof path, "%s/ports/%d/counters/port_rcv_data",
-						    ibc->ibha, ibc->port);
-	ibc->pathrcvb = malloc( strlen(path)+1 );
-	strcpy(ibc->pathrcvb, path);
-
-	snprintf(path, sizeof path, "%s/ports/%d/counters/port_xmit_data",
-						    ibc->ibha, ibc->port);
-	ibc->pathsndb = malloc( strlen(path)+1 );
-	strcpy(ibc->pathsndb, path);
-
-	snprintf(path, sizeof path, "%s/ports/%d/counters/port_rcv_packets",
-						    ibc->ibha, ibc->port);
-	ibc->pathrcvp = malloc( strlen(path)+1 );
-	strcpy(ibc->pathrcvp, path);
-
-	snprintf(path, sizeof path, "%s/ports/%d/counters/port_xmit_packets",
-						    ibc->ibha, ibc->port);
-	ibc->pathsndp = malloc( strlen(path)+1 );
-	strcpy(ibc->pathsndp, path);
 }
 
 /*

--- a/photosyst.c
+++ b/photosyst.c
@@ -1946,6 +1946,32 @@ ibprep(struct ibcachent *ibc)
 	FILE	*fp;
 	char	path[128], linebuf[64], speedunit;
 
+    // build all pathnames to obtain the counters
+    // of this port later on
+    snprintf(path, sizeof path,
+             "%s/ports/%d/counters/port_rcv_data",
+             ibc->ibha, ibc->port);
+    ibc->pathrcvb = malloc( strlen(path)+1 );
+    strcpy(ibc->pathrcvb, path);
+
+    snprintf(path, sizeof path,
+             "%s/ports/%d/counters/port_xmit_data",
+             ibc->ibha, ibc->port);
+    ibc->pathsndb = malloc( strlen(path)+1 );
+    strcpy(ibc->pathsndb, path);
+
+    snprintf(path, sizeof path,
+             "%s/ports/%d/counters/port_rcv_packets",
+             ibc->ibha, ibc->port);
+    ibc->pathrcvp = malloc( strlen(path)+1 );
+    strcpy(ibc->pathrcvp, path);
+
+    snprintf(path, sizeof path,
+             "%s/ports/%d/counters/port_xmit_packets",
+             ibc->ibha, ibc->port);
+    ibc->pathsndp = malloc( strlen(path)+1 );
+    strcpy(ibc->pathsndp, path);
+
 	// determine port rate and number of lanes
 	snprintf(path, sizeof path, "%s/ports/%d/rate", ibc->ibha, ibc->port); 
 
@@ -1971,33 +1997,12 @@ ibprep(struct ibcachent *ibc)
                 ibc->rate *= 1000000;
                 break;
             }
-
-            // build all pathnames to obtain the counters
-            // of this port later on
-            snprintf(path, sizeof path,
-                     "%s/ports/%d/counters/port_rcv_data",
-                     ibc->ibha, ibc->port);
-            ibc->pathrcvb = malloc( strlen(path)+1 );
-            strcpy(ibc->pathrcvb, path);
-
-            snprintf(path, sizeof path,
-                     "%s/ports/%d/counters/port_xmit_data",
-                     ibc->ibha, ibc->port);
-            ibc->pathsndb = malloc( strlen(path)+1 );
-            strcpy(ibc->pathsndb, path);
-
-            snprintf(path, sizeof path,
-                     "%s/ports/%d/counters/port_rcv_packets",
-                     ibc->ibha, ibc->port);
-            ibc->pathrcvp = malloc( strlen(path)+1 );
-            strcpy(ibc->pathrcvp, path);
-
-            snprintf(path, sizeof path,
-                     "%s/ports/%d/counters/port_xmit_packets",
-                     ibc->ibha, ibc->port);
-            ibc->pathsndp = malloc( strlen(path)+1 );
-            strcpy(ibc->pathsndp, path);
-		}
+        }
+        else
+        {
+            ibc->lanes = 0;
+            ibc->rate = 0;
+        }
 
 		fclose(fp);
 	}


### PR DESCRIPTION
Make sure that we successfully read data from rate file to avoid usage of uninitialized local variables.