### PR TITLE
DEFPATH not created so touch fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,8 @@ sysvinstall:	genericinstall
 genericinstall:	atop atopacctd atopconvert
 		if [ ! -d $(DESTDIR)$(LOGPATH) ]; 		\
 		then	mkdir -p $(DESTDIR)$(LOGPATH); fi
+		if [ ! -d $(DESTDIR)$(DEFPATH) ]; 		\
+		then	mkdir -p $(DESTDIR)$(DEFPATH); fi
 		if [ ! -d $(DESTDIR)$(BINPATH) ]; 		\
 		then	mkdir -p $(DESTDIR)$(BINPATH); fi
 		if [ ! -d $(DESTDIR)$(SBINPATH) ]; 		\


### PR DESCRIPTION
```
touch               /build/atop/pkg/atop/etc/default/atop
touch: cannot touch '/build/atop/pkg/atop/etc/default/atop': No such file or directory
```

Add DEFPATH mkdir in genericinstall to make sure the folder
`$(DESTDIR)/etc/default` exits

Signed-off-by: BlackEagle <ike.devolder@gmail.com>