### PR TITLE
show disk avio values in microseconds or nanoseconds as appropriate

### DIFF
--- a/showsys.c
+++ b/showsys.c
@@ -1832,14 +1832,26 @@ sysprt_DSKAVIO(void *p, void *q, int badness, int *color)
         if (tim > 100.0)
         {
                 sprintf(buf+5, "%4.0lf ms", tim);
-        } 
-        else if (tim > 10.0) 
+        }
+        else if (tim > 10.0)
         {
                 sprintf(buf+5, "%4.1lf ms", tim);
         }
-        else 
+        else if (tim > 0.1)
         {
-                sprintf(buf+5, "%4.2lf ms", tim);
+                sprintf(buf+5, "%3.2lf ms", tim);
+        }
+        else if (tim > 0.01)
+        {
+                sprintf(buf+5, "%4.1lf µs", tim * 1000.0);
+        }
+        else if (tim > 0.0001)
+        {
+                sprintf(buf+5, "%4.2lf µs", tim * 1000.0);
+        }
+        else
+        {
+                sprintf(buf+5, "%4.1lf ns", tim * 1000000.0);
         }
 
         return buf;


### PR DESCRIPTION
I've got a (very nice) drive that regularly has avio times in the single-digit microseconds, which normally shows as 0.00ms.