### PR TITLE
Compilation Warning - Unused Result on system calls

### DIFF
--- a/atopacctd.c
+++ b/atopacctd.c
@@ -134,6 +134,7 @@ main(int argc, char *argv[])
 	time_t			gclast = time(0);
 
 	struct sigaction	sigcleanup;
+	int			liResult;
 
 	/*
 	** argument passed?
@@ -304,7 +305,16 @@ main(int argc, char *argv[])
 
 	umask(022);
 
-	(void) chdir("/tmp");			// go to a safe place
+	liResult = chdir("/tmp");			// go to a safe place
+	if( liResult != 0 )
+	{
+		char lcMessage[ 64 ];
+		memset( lcMessage, 0, sizeof( lcMessage ) );
+		snprintf( lcMessage, sizeof( lcMessage ) - 1,
+		          "%s:%d - Error %d changing to tmp dir\n", 
+		          __FILE__, __LINE__, errno );
+		fprintf( stderr, "%s", lcMessage );
+	}
 
 	/*
 	** increase semaphore to define that atopacctd is running
@@ -368,7 +378,7 @@ main(int argc, char *argv[])
 	** raise priority (be sure the nice value becomes -20,
 	** independent of the current nice value)
 	*/
-	(void) nice(-39);
+	liResult = nice(-39);
 
 	/*
  	** connect to NETLINK socket of kernel to be triggered
@@ -966,6 +976,7 @@ setcurrent(long curshadow)
 	static int	cfd = -1;
 	char		currentpath[128], currentdata[128];
 	int		len;
+	int		liResult;
 
 	/*
 	** assemble file name of currency file and open (only once)
@@ -992,9 +1003,28 @@ setcurrent(long curshadow)
 	/*
 	** wipe currency file and write new assembled string
 	*/
-	(void) ftruncate(cfd, 0);
+	liResult = ftruncate(cfd, 0);
+	if( liResult != 0 )
+	{
+		char lcMessage[ 64 ];
+		memset( lcMessage, 0, sizeof( lcMessage ) );
+		snprintf( lcMessage, sizeof( lcMessage ) - 1,
+		          "%s:%d - Error %d ftruncate\n\n", __FILE__, __LINE__,
+		          errno );
+		fprintf( stderr, "%s", lcMessage );
+	}
+
 	(void) lseek(cfd, 0, SEEK_SET);
-	(void) write(cfd, currentdata, len);
+	liResult = write(cfd, currentdata, len);
+	if( liResult != 0 )
+	{
+		char lcMessage[ 64 ];
+		memset( lcMessage, 0, sizeof( lcMessage ) );
+		snprintf( lcMessage, sizeof( lcMessage ) - 1,
+		          "%s:%d - Error %d writing\n\n", __FILE__, __LINE__,
+		          errno );
+		fprintf( stderr, "%s", lcMessage );
+	}
 }
 
 /*

--- a/rawlog.c
+++ b/rawlog.c
@@ -37,6 +37,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <ctype.h>
+#include <string.h>
 #include <sys/utsname.h>
 #include <string.h>
 #include <regex.h>
@@ -657,11 +658,21 @@ rawread(void)
 					next_pos = lseek(rawfd, rr.scomplen+rr.pcomplen, SEEK_CUR);
 					if ((curr_pos >> READAHEADOFF) != (next_pos >> READAHEADOFF))
 					{
+						int liResult;
 						/* just read READAHEADSIZE bytes into page cache */
 						char *buf = malloc(READAHEADSIZE);
 						ptrverify(buf, "Malloc failed for readahead");
-						pread(rawfd, buf, READAHEADSIZE,
+						liResult = pread(rawfd, buf, READAHEADSIZE,
 							next_pos & ~(READAHEADSIZE - 1));
+						if( liResult != 0 )
+						{
+							char lcMessage[ 64 ];
+							memset( lcMessage, 0, sizeof( lcMessage ) );
+							snprintf( lcMessage, sizeof( lcMessage ) - 1,
+								  "%s:%d - Error %d in readahead\n",
+							          __FILE__, __LINE__, errno );
+							fprintf( stderr, "%s", lcMessage );
+						}
 						free(buf);
 					}
 					curr_pos = next_pos;

--- a/various.c
+++ b/various.c
@@ -111,6 +111,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <stdarg.h>
+#include <string.h>
 
 #include "atop.h"
 #include "acctproc.h"
@@ -633,5 +634,16 @@ droprootprivs(void)
 void
 regainrootprivs(void)
 {
-	seteuid(0);
+	int liResult;
+
+	liResult = seteuid(0);
+	if( liResult != 0 )
+	{
+		char lcMessage[ 64 ];
+		memset( lcMessage, 0, sizeof( lcMessage ) );
+		snprintf( lcMessage, sizeof( lcMessage ) - 1,
+		          "%s:%d - Error %d setting EUID\n", __FILE__, __LINE__,
+		          errno );
+		fprintf( stderr, "%s", lcMessage );
+	}
 }


### PR DESCRIPTION
Newer versions of gcc enforce to check the result of system calls

No changes in behaviour