### PR TITLE
Compilation warnings - String Manipulation

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -1587,7 +1587,7 @@ lvmmapname(unsigned int major, unsigned int minor,
 		DIR		*dirp;
 		struct dirent	*dentry;
 		struct stat	statbuf;
-		char		path[64];
+		char		path[ PATH_MAX ];
 
 		if ( (dirp = opendir(MAPDIR)) )
 		{
@@ -1826,7 +1826,7 @@ get_infiniband(struct ifbstat *si)
 
 	if (firstcall)
 	{
-		char		path[128], *p;
+		char		path[ PATH_MAX ], *p;
 		struct stat	statbuf;
 		struct dirent	*contdent, *portdent;
 		DIR		*contp, *portp;
@@ -1942,7 +1942,7 @@ static void
 ibprep(struct ibcachent *ibc)
 {
 	FILE	*fp;
-	char	path[128], linebuf[64], speedunit;
+	char	path[ PATH_MAX ], linebuf[64], speedunit;
 
 	// determine port rate and number of lanes
 	snprintf(path, sizeof path, "%s/ports/%d/rate", ibc->ibha, ibc->port); 

--- a/showsys.c
+++ b/showsys.c
@@ -2208,6 +2208,14 @@ sysprt_NETNAME(void *p, void *q, int badness, int *color)
                                		(sstat->intf.intf[as->index].speed *10);
 		}
 
+		if( busy < 0 )
+		{
+			busy = 0;
+		}		
+		else if( busy > 999 )
+		{
+			busy = 999;
+		}
 	        snprintf(buf, sizeof(buf)-1, "%-7.7s %3lld%%", 
        		          sstat->intf.intf[as->index].name, busy);
 
@@ -2288,7 +2296,16 @@ char *makenetspeed(count_t val, int nsecs)
                 c = 'T';
         }
 
-        sprintf(buf+3, "%4lld %cbps", val, c);
+        if( val < 0 )
+        {
+                val = 0;
+        }
+        else if( val > 9999 )
+        {
+                val = 9999;
+        }
+
+        snprintf(buf+3, sizeof( buf ) - 3, "%4lld %cbps", val, c);
 
         return buf;
 }
@@ -2303,6 +2320,9 @@ sysprt_NETSPEEDMAX(void *p, void *q, int badness, int *color)
 
 	*color = -1;
 
+	if (speed < 0 )
+		speed = 0;
+
 	if (speed < 10000)
 	{
         	snprintf(buf, sizeof buf, "sp %4lld Mbps", speed);
@@ -2310,6 +2330,10 @@ sysprt_NETSPEEDMAX(void *p, void *q, int badness, int *color)
 	else
 	{
 		speed /= 1000;
+		if( speed > 9999 )
+		{
+			speed = 9999;
+		}
         	snprintf(buf, sizeof buf, "sp %4lld Gbps", speed);
 	}
 
@@ -2508,6 +2532,10 @@ sysprt_IFBSPEEDMAX(void *p, void *q, int badness, int *color)
 	else
 	{
 		rate /= 1000;
+		if( rate > 9999 )
+		{
+			rate = 9999;
+		}
         	snprintf(buf, sizeof buf, "sp %4lld Gbps", rate);
 	}
 


### PR DESCRIPTION
Changed the size of path variable using system constant

Implemented data size check during message creation to avoid buffer overflow and problems when displaying messages.

Now negative numbers are presented as 0(zero) and to big numbers are presented as maximum value(ex.9999). This will avoid problems in case of invalid or unexpected data.

This was tested compiling in 32 and 64 bits.