### PR TITLE
disable atop-rotate.timer when uninstall

### DIFF
--- a/rpmspec/atop.specsystemd
+++ b/rpmspec/atop.specsystemd
@@ -79,6 +79,7 @@ then
 	/bin/systemctl disable --now atop
 	/bin/systemctl disable --now atopacct
 	/bin/systemctl disable --now atopgpu
+	/bin/systemctl disable --now atop-rotate.timer
 fi
 
 # atop-XVERSX and atopsar-XVERSX will remain for old logfiles


### PR DESCRIPTION
Spec file of systemd indicates install and enable atop-rotate.timer  when installing, but never stop/disable it when uninstalling. 

This PR fix it. 