### PR TITLE
Support time spent waiting on a runqueue collection

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -462,6 +462,10 @@ deviattask(struct tstat    *curtpres, unsigned long ntaskpres,
 			devstat->cpu.utime  = curstat->cpu.utime -
 			                      prestat.cpu.utime;
 
+		if (curstat->cpu.rundelay > prestat.cpu.rundelay)
+			devstat->cpu.rundelay  = curstat->cpu.rundelay -
+						 prestat.cpu.rundelay;
+
 		if (curstat->mem.minflt > prestat.mem.minflt)
 			devstat->mem.minflt = curstat->mem.minflt - 
 			                      prestat.mem.minflt;
@@ -635,6 +639,8 @@ calcdiff(struct tstat *devstat, struct tstat *curstat, struct tstat *prestat,
 	if (devstat->cpu.utime > totusedcpu)
 		devstat->cpu.utime = 1;
 
+	devstat->cpu.rundelay  =
+		subcount(curstat->cpu.rundelay, prestat->cpu.rundelay);
 	/*
 	** do further calculations
 	*/

--- a/photoproc.h
+++ b/photoproc.h
@@ -75,7 +75,8 @@ struct tstat {
 		int	curcpu;		/* current processor            */
 		int	sleepavg;       /* sleep average percentage     */
 		int	ifuture[4];	/* reserved for future use	*/
-		count_t	cfuture[4];	/* reserved for future use	*/
+		count_t	rundelay;	/* sched stat run delay		*/
+		count_t	cfuture[3];	/* reserved for future use	*/
 	} cpu;
 
 	/* DISK STATISTICS						*/

--- a/showlinux.c
+++ b/showlinux.c
@@ -551,6 +551,7 @@ proc_printdef *allprocpdefs[]=
 	&procprt_PPID,
 	&procprt_SYSCPU,
 	&procprt_USRCPU,
+	&procprt_RUNDELAY,
 	&procprt_VGROW,
 	&procprt_RGROW,
 	&procprt_MINFLT,
@@ -1289,7 +1290,7 @@ priphead(int curlist, int totlist, char *showtype, char *showorder,
                 make_proc_prints(schedprocs, MAXITEMS, 
                         "PID:10 TID:6 CID:5 VPID:4 CTID:4 TRUN:7 TSLPI:7 "
 			"TSLPU:7 POLI:8 NICE:9 PRI:9 RTPR:9 CPUNR:8 ST:8 "
-			"EXC:8 S:8 SORTITEM:10 CMD:10", 
+			"EXC:8 S:8 RDELAY:8 SORTITEM:10 CMD:10",
                         "built-in schedprocs");
 
                 make_proc_prints(dskprocs, MAXITEMS, 

--- a/showlinux.h
+++ b/showlinux.h
@@ -373,6 +373,7 @@ extern proc_printdef procprt_GPUMEMAVG;
 extern proc_printdef procprt_GPUGPUBUSY;
 extern proc_printdef procprt_GPUMEMBUSY;
 extern proc_printdef procprt_SORTITEM;
+extern proc_printdef procprt_RUNDELAY;
 
 
 

--- a/showprocs.c
+++ b/showprocs.c
@@ -2041,3 +2041,24 @@ procprt_SORTITEM_ae(struct tstat *curstat, int avgval, int nsecs)
 
 proc_printdef procprt_SORTITEM = 
    { 0, "SORTITEM", procprt_SORTITEM_ae, procprt_SORTITEM_ae, 4 };
+/***************************************************************/
+char *
+procprt_RUNDELAY_a(struct tstat *curstat, int avgval, int nsecs)
+{
+        static char buf[10];
+
+        val2cpustr(curstat->cpu.rundelay/10000/hertz, buf);
+        return buf;
+}
+
+char *
+procprt_RUNDELAY_e(struct tstat *curstat, int avgval, int nsecs)
+{
+        static char buf[10];
+
+        snprintf(buf, sizeof buf, "     -");
+        return buf;
+}
+
+proc_printdef procprt_RUNDELAY =
+   { "RDELAY", "RDELAY", procprt_RUNDELAY_a, procprt_RUNDELAY_e, 6 };


### PR DESCRIPTION
Collect run delay information from /proc/<pid>/schedstat, and show
in schedproc page.

It's helpful for latency spike trouble shooting case.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>