### PR TITLE
Try to set the highest OOM priority for atop

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -694,6 +694,8 @@ main(int argc, char *argv[])
 	if ( nice(-20) == -1)
 		;
 
+	set_oom_score_adj();
+
 	/*
 	** switch-on the process-accounting mechanism to register the
 	** (remaining) resource-usage by processes which have finished

--- a/atop.h
+++ b/atop.h
@@ -193,3 +193,4 @@ unsigned int	netatop_exitstore(void);
 void		netatop_exiterase(void);
 void		netatop_exithash(char);
 void		netatop_exitfind(unsigned long, struct tstat *, struct tstat *);
+void		set_oom_score_adj(void);

--- a/various.c
+++ b/various.c
@@ -112,6 +112,7 @@
 #include <errno.h>
 #include <stdarg.h>
 #include <string.h>
+#include <fcntl.h>
 
 #include "atop.h"
 #include "acctproc.h"
@@ -709,4 +710,28 @@ regainrootprivs(void)
 	if (liResult != 0)
 	{
 	}
+}
+
+/*
+** try to set the highest OOM priority
+*/
+void
+set_oom_score_adj(void)
+{
+	int fd;
+	char val[] = "-1000";	/* suggested by Gerlof, always set -1000 */
+
+	/*
+	 ** set OOM score adj to avoid to lost necessary log of system.
+	 ** ignored if not running under superuser priviliges!
+	 */
+	fd = open("/proc/self/oom_score_adj", O_RDWR);
+	if ( fd < 0 ) {
+		return;
+	}
+
+	if ( write(fd, val, strlen(val)) < 0 )
+		;
+
+	close(fd);
 }


### PR DESCRIPTION
We usually expect that atop has highest OOM priority. when the system
runs out of memory, atop still could record necessary infomation.
Then we are able to analyze the OOM situation afterwards.

The orignal verion of this feature: read config from atoprc, then
apply to atop process. But Gerlof considers that just trying to set
the highest priority is better. So rewrite this as Gerlof's advise.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>