### PR TITLE
ifprop.c: fix build with kernel < 4.6

### DIFF
--- a/ifprop.c
+++ b/ifprop.c
@@ -104,7 +104,9 @@ initifprop(void)
 	char 				*cp, linebuf[2048];
 	int				i=0, sockfd;
 
+#ifdef ETHTOOL_GLINKSETTINGS
 	struct ethtool_link_settings 	ethlink;	// preferred!
+#endif
 	struct ethtool_cmd 		ethcmd;		// deprecated	
 
 	struct ifreq		 	ifreq;
@@ -153,6 +155,7 @@ initifprop(void)
 		strncpy((void *)&ifreq.ifr_ifrn.ifrn_name, ifprops[i].name,
 				sizeof ifreq.ifr_ifrn.ifrn_name-1);
 
+#ifdef ETHTOOL_GLINKSETTINGS
 		ethlink.cmd              = ETHTOOL_GLINKSETTINGS;
 		ifreq.ifr_ifru.ifru_data = (void *)&ethlink;
 
@@ -164,6 +167,7 @@ initifprop(void)
 			phy_addr = ethlink.phy_address;
 		}
 		else
+#endif
 		{
 			ethcmd.cmd               = ETHTOOL_GSET;
 			ifreq.ifr_ifru.ifru_data = (void *)&ethcmd;


### PR DESCRIPTION
Build fails with kernel headers < 4.6 since version 2.6.0 and https://github.com/Atoptool/atop/commit/08c622ecaa5bb0bb260984ceaddc4730d1b312a7

Indeed, `ethtool_link_settings` and `ETHTOOL_GLINKSETTINGS` are only available since https://github.com/torvalds/linux/commit/3f1ac7a700d039c61d8d8b99f28d605d489a60cf

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>