### PR TITLE
Fix atop stuck when reading offline css

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,8 @@ PMPATH1  = /usr/lib/pm-utils/sleep.d
 PMPATH2  = /usr/lib64/pm-utils/sleep.d
 PMPATHD  = /usr/lib/systemd/system-sleep
 
-CFLAGS  += -O2 -I. -Wall -Wno-stringop-truncation # -DNOPERFEVENT   # -DHTTPSTATS
+CFLAGS  += -O2 -I. -Wall -Wno-stringop-truncation $(shell pkg-config --cflags glib-2.0)  # -DNOPERFEVENT   # -DHTTPSTATS
+LDFLAGS  = $(shell pkg-config --libs glib-2.0)
 OBJMOD0  = version.o
 OBJMOD1  = various.o  deviate.o   procdbase.o
 OBJMOD2  = acctproc.o photoproc.o photosyst.o  rawlog.o ifprop.o parseable.o


### PR DESCRIPTION
Let's read /sys/fs/cgroup/cpuset/.../.../container_id as
a workaround for the fatal case when css_tryget() meets
offline css and then gets stuck indefinitely. And use nftw
to get each container_id's tasks.

The corresponding kernel patch is as follows:
https://lore.kernel.org/lkml/20190617210753.742447720@linuxfoundation.org/

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>