### PR TITLE
Switch to using curses vw_printw as vwprintw is deprecated

### DIFF
--- a/showgeneric.c
+++ b/showgeneric.c
@@ -2721,7 +2721,7 @@ printg(const char *format, ...)
 	va_start(args, format);
 
 	if (screen)
-		vwprintw(stdscr, (char *) format, args);
+		vw_printw(stdscr, (char *) format, args);
 	else
 		vprintf(format, args);
 


### PR DESCRIPTION
Resolves the following compiler warning -

showgeneric.c: In function ‘printg’:
showgeneric.c:2724:3: warning: ‘vwprintw’ is deprecated [-Wdeprecated-declarations]