### PR TITLE
photosyst.c: fix build on musl

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -46,6 +46,7 @@
 #include <dirent.h>
 #include <sys/ioctl.h>
 #include <sys/sysmacros.h>
+#include <limits.h>
 
 #define SCALINGMAXCPU	8	// threshold for scaling info per CPU
 


### PR DESCRIPTION
Build on musl is broken since version 2.6.0 and https://github.com/Atoptool/atop/commit/e889c66fbe1d0b7ae38fbcbaa46cea749257f486 because `limits.h` is not included:

```
photosyst.c: In function ‘lvmmapname’:
photosyst.c:1624:14: error: ‘PATH_MAX’ undeclared (first use in this function); did you mean ‘AF_MAX’?
   char  path[PATH_MAX];
              ^~~~~~~~
              AF_MAX
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>