### PR TITLE
Support page migration counter

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -701,6 +701,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 	dev->mem.oomkills	= subcount(cur->mem.oomkills, pre->mem.oomkills);
 	dev->mem.compactstall	= subcount(cur->mem.compactstall,
 				                         pre->mem.compactstall);
+	dev->mem.pgmigrate	= subcount(cur->mem.pgmigrate, pre->mem.pgmigrate);
 
 	dev->psi          	= cur->psi;
 

--- a/man/atop.1
+++ b/man/atop.1
@@ -1241,8 +1241,9 @@ and the number of process stalls to run memory compaction to allocate
 huge pages (`compact').
 .br
 Also the number of memory pages the system read from swap space (`swin'),
-the number of memory pages the system wrote to swap space (`swout'), and
-the number of out-of-memory kills (`oomkill') are shown.
+the number of memory pages the system wrote to swap space (`swout'),
+the number of out-of-memory kills (`oomkill') and
+the number of memory pages the system migrated between NUMA nodes (`migrate') are shown.
 .PP
 .TP 5
 .B PSI

--- a/parseable.c
+++ b/parseable.c
@@ -463,7 +463,7 @@ print_SWP(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 void
 print_PAG(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 {
-	printf("%s %u %lld %lld %lld %lld %lld %lld %lld\n",
+	printf("%s %u %lld %lld %lld %lld %lld %lld %lld %lld\n",
 			hp,
 			pagesize,
 			ss->mem.pgscans,
@@ -472,7 +472,8 @@ print_PAG(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 			ss->mem.swins,
 			ss->mem.swouts,
 			ss->mem.oomkills,
-			ss->mem.compactstall);
+			ss->mem.compactstall,
+			ss->mem.pgmigrate);
 }
 
 void

--- a/photosyst.c
+++ b/photosyst.c
@@ -479,6 +479,7 @@ photosyst(struct sstat *si)
 	*/
 	si->mem.oomkills   = -1;
 	si->mem.allocstall = 0;
+	si->mem.pgmigrate  = 0;
 
 	if ( (fp = fopen("vmstat", "r")) != NULL)
 	{
@@ -527,6 +528,11 @@ photosyst(struct sstat *si)
 			}
 			if ( strcmp("compact_stall", nam) == EQ) {
 				si->mem.compactstall = cnts[0];
+				continue;
+			}
+
+			if ( strcmp("pgmigrate_success", nam) == EQ) {
+				si->mem.pgmigrate = cnts[0];
 				continue;
 			}
 		}

--- a/photosyst.h
+++ b/photosyst.h
@@ -81,6 +81,7 @@ struct	memstat {
 	count_t	zswtotpool;	// total pool size (pages)
 	count_t	oomkills;	// number of oom killings
 	count_t	compactstall;	// counter for process stalls
+	count_t	pgmigrate;	// counter for migrated successfully (pages)
 };
 
 /************************************************************************/

--- a/showlinux.c
+++ b/showlinux.c
@@ -415,6 +415,7 @@ sys_printdef *pagsyspdefs[] = {
 	&syspdef_PAGSWIN,
 	&syspdef_PAGSWOUT,
 	&syspdef_OOMKILLS,
+	&syspdef_PGMIGRATE,
 	&syspdef_BLANKBOX,
         0
 };
@@ -1136,7 +1137,8 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
 	                "BLANKBOX:0 "
 	                "PAGSWIN:4 "
 	                "PAGSWOUT:5"
-			"OOMKILLS:6",
+			"OOMKILLS:6"
+			"PGMIGRATE:6",
 			pagsyspdefs, "builtin pagline",
 			sstat, &extra);
                 }
@@ -1978,7 +1980,8 @@ prisyst(struct sstat *sstat, int curline, int nsecs, int avgval,
             sstat->mem.compactstall 	||
             sstat->mem.swins      	||
             sstat->mem.swouts     	||
-            sstat->mem.oomkills     	  )
+            sstat->mem.oomkills     	||
+            sstat->mem.pgmigrate     	  )
         {
                 busy = sstat->mem.swouts / nsecs * pagbadness;
 

--- a/showlinux.h
+++ b/showlinux.h
@@ -208,6 +208,7 @@ extern sys_printdef syspdef_PAGCOMPACT;
 extern sys_printdef syspdef_PAGSWIN;
 extern sys_printdef syspdef_PAGSWOUT;
 extern sys_printdef syspdef_OOMKILLS;
+extern sys_printdef syspdef_PGMIGRATE;
 extern sys_printdef syspdef_PSICPUSTOT;
 extern sys_printdef syspdef_PSIMEMSTOT;
 extern sys_printdef syspdef_PSIMEMFTOT;

--- a/showsys.c
+++ b/showsys.c
@@ -1667,6 +1667,24 @@ sysprt_OOMKILLS(void *p, void *q, int badness, int *color)
 }
 
 sys_printdef syspdef_OOMKILLS = {"OOMKILLS", sysprt_OOMKILLS};
+
+/*******************************************************************/
+char *
+sysprt_PGMIGRATE(void *p, void *q, int badness, int *color)
+{
+        struct sstat *sstat=p;
+        extraparam *as=q;
+        static char buf[16]="migrate  ";
+
+	if (sstat->mem.pgmigrate == -1)	// non-existing?
+		return NULL;
+
+        val2valstr(sstat->mem.pgmigrate, buf+8, 4, as->avgval, as->nsecs);
+        return buf;
+}
+
+sys_printdef syspdef_PGMIGRATE = {"PGMIGRATE", sysprt_PGMIGRATE};
+
 /*******************************************************************/
 // general formatting of PSI field in avg10/avg60/avg300
 void


### PR DESCRIPTION
The kernel may migrate pages between NUMA nodes to make memory access
faster, but during migration the kernel need hold the memory lock of
target process and trigger TLB flush. It hurts the performance a lot.

Add pgmigrate counter to show/record it for trouble shooting.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>