### PR TITLE
Fix using prestat but without initialization

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -141,6 +141,8 @@ deviattask(struct tstat    *curtpres, unsigned long ntaskpres,
 		if ( pdb_gettask(curstat->gen.pid, curstat->gen.isproc,
 		                 curstat->gen.btime, &pinfo))
 		{
+			prestat 	= pinfo->tstat;
+
 			/*
 			** task already present in the previous sample
 			**
@@ -163,7 +165,6 @@ deviattask(struct tstat    *curtpres, unsigned long ntaskpres,
 				** and overwrite the previous sample in
 				** the database with the current sample
 				*/
-				prestat 	= pinfo->tstat;
 				pinfo->tstat 	= *curstat;
 
 				curstat->gen.wasinactive = 0;


### PR DESCRIPTION
In deviattask(), for tasks already presented in the previous sample,
we also need to assign a value to "prestat" even if "curstat" is equal
to "prestat". Or else we will get a stale value when "prestat" is
referenced later in calcdiff().

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>