### PR TITLE
Support NVMe multipath disk statistics

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -1629,6 +1629,7 @@ static struct {
 	{ "^md[0-9][0-9]*$",			{0},  nullmodname, MDDTYPE, },
 	{ "^vd[a-z][a-z]*$",                    {0},  nullmodname, DSKTYPE, },
 	{ "^nvme[0-9][0-9]*n[0-9][0-9]*$",	{0},  nullmodname, DSKTYPE, },
+	{ "^nvme[0-9][0-9]*c[0-9][0-9]*n[0-9][0-9]*$", {0}, nullmodname, DSKTYPE, },
 	{ "^nbd[0-9][0-9]*$",			{0},  nullmodname, DSKTYPE, },
 	{ "^hd[a-z]$",				{0},  nullmodname, DSKTYPE, },
 	{ "^rd/c[0-9][0-9]*d[0-9][0-9]*$",	{0},  nullmodname, DSKTYPE, },


### PR DESCRIPTION
When NVMe disk multi-path is turned on, the kernel only records IO statistics
for each multi-path.

Ex, read statistics from /proc/diskstatus:
0       0 nvme0c0n1 34706049 74843 4815165730 93876201 4187610 1925219 6989322264 47813633 0 45557635 118897696 312571 0 11200562376 857547
259     1 nvme0n1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0

For this case, we usually expect the right statistics from nvme0c0n1 instead of nvme0n1.

Signed-off-by: enhua zhou zhouenhua@bytedance.com