### PR TITLE
pricumproc: fix using but without initialization

### DIFF
--- a/showlinux.c
+++ b/showlinux.c
@@ -998,6 +998,20 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
         extra.nsecs	= nsecs;
         extra.index	= 0;
 
+        /*
+        ** CPU statistics
+        */
+        extra.cputot = sstat->cpu.all.stime + sstat->cpu.all.utime +
+                       sstat->cpu.all.ntime + sstat->cpu.all.itime +
+                       sstat->cpu.all.wtime + sstat->cpu.all.Itime +
+                       sstat->cpu.all.Stime + sstat->cpu.all.steal;
+        if (extra.cputot == 0)
+                extra.cputot = 1;             /* avoid divide-by-zero */
+
+        extra.percputot = extra.cputot / sstat->cpu.nrcpu;
+        if (extra.percputot == 0)
+                extra.percputot = 1;          /* avoid divide-by-zero */
+
         if (firsttime)
         {
                 firsttime=0;


### PR DESCRIPTION
The "permissables[j]->doconvert()" was added for make_sys_prints()
in former commit 09935eb to check the valid counter, but it also
introduces a using without initialization issue.

In current code, 'as->percputot' is actually assigned in prisyst(),
but this value is used earlier in sysprt_CPUSYS() when this function
is called by pricumproc() => make_sys_prints(). In this way, a
'buffer overflow detected' error message will be triggered via
___sprintf_chk() while compiling.

Fix this by assigning for 'as->percputot' earlier in pricumproc().

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>