### PR TITLE
Polish do_perfevents when atop built with NOPERFEVENT

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -2475,6 +2475,7 @@ get_hypervisor(void)
 void
 do_perfevents(char *tagname, char *tagvalue)
 {
-	mcleanstop(1, "atop built with NOPERFEVENT, cannot use perfevents\n");
+	if (strcmp("disable", tagvalue))
+		mcleanstop(1, "atop built with NOPERFEVENT, cannot use perfevents\n");
 }
 #endif


### PR DESCRIPTION
The phenomenon is supposing one atop package whose code is older than
commit: 961a6ce13 has been installed and 'perfevents disable' is also
defined in atoprc. When trying to update to a version newer than that
commit, the new atop will crash saying 'atop built with NOPERFEVENT,
cannot use perfevents'. And the result is we have to remove the tag
in atoprc before we do update, which is quite inconvenient.

Although perf is forbidden when atop is built with NOPERFEVENT,
defining 'perfevents disable' in atoprc can actually be allowed. Let's
avoid that unfriendly crash by making the check code tolerate with
the 'perfevents disable' tag in /etc/atoprc.

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>