### PR TITLE
Add 'offcpu' field in CPL

### DIFF
--- a/atop.h
+++ b/atop.h
@@ -198,3 +198,4 @@ void		netatop_exiterase(void);
 void		netatop_exithash(char);
 void		netatop_exitfind(unsigned long, struct tstat *, struct tstat *);
 void		set_oom_score_adj(void);
+int		cpulistnr(const char *cpulist);

--- a/deviate.c
+++ b/deviate.c
@@ -607,6 +607,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 	struct ifprop	ifprop;
 
 	dev->cpu.nrcpu     = cur->cpu.nrcpu;
+	dev->cpu.offcpu     = cur->cpu.offcpu;
 	dev->cpu.devint    = subcount(cur->cpu.devint, pre->cpu.devint);
 	dev->cpu.csw       = subcount(cur->cpu.csw,    pre->cpu.csw);
 	dev->cpu.nprocs    = subcount(cur->cpu.nprocs, pre->cpu.nprocs);

--- a/man/atop.1
+++ b/man/atop.1
@@ -1159,7 +1159,8 @@ or that are waiting for disk I/O. These figures are averaged over
 1 (`avg1'), 5 (`avg5') and 15 (`avg15') minutes.
 .br
 Furthermore the number of context switches (`csw'), the number
-of serviced interrupts (`intr') and the number of available CPUs are shown.
+of serviced interrupts (`intr') and the number of available CPUs(`numcpu') 
+are shown.
 
 If the screen-width does not allow all of these counters,
 only a relevant subset is shown.
@@ -2074,7 +2075,7 @@ instructions executed by this CPU and cycles for this CPU.
 .TP 9
 .B CPL
 Subsequent fields:
-number of processors,
+number of available processors,
 load average for last minute,
 load average for last five minutes,
 load average for last fifteen minutes,

--- a/man/atop.1
+++ b/man/atop.1
@@ -1159,8 +1159,8 @@ or that are waiting for disk I/O. These figures are averaged over
 1 (`avg1'), 5 (`avg5') and 15 (`avg15') minutes.
 .br
 Furthermore the number of context switches (`csw'), the number
-of serviced interrupts (`intr') and the number of available CPUs(`numcpu') 
-are shown.
+of serviced interrupts (`intr'), the number of available CPUs(`numcpu') 
+and the number of offline CPUs(`offcpu') are shown.
 
 If the screen-width does not allow all of these counters,
 only a relevant subset is shown.
@@ -2076,6 +2076,7 @@ instructions executed by this CPU and cycles for this CPU.
 .B CPL
 Subsequent fields:
 number of available processors,
+number of offline processors,
 load average for last minute,
 load average for last five minutes,
 load average for last fifteen minutes,

--- a/photosyst.c
+++ b/photosyst.c
@@ -475,6 +475,23 @@ photosyst(struct sstat *si)
         }
 
 	/*
+	** gather offline CPU list from the file /sys/devices/system/cpu/offline
+	*/
+	if ( (fp = fopen("/sys/devices/system/cpu/offline", "r")) != NULL)
+	{
+		if ( fgets(linebuf, sizeof(linebuf), fp) != NULL)
+		{
+			int offcpu = cpulistnr(linebuf);
+			if (offcpu > 0)
+			{
+				si->cpu.offcpu = offcpu;
+			}
+		}
+
+		fclose(fp);
+	}
+
+	/*
 	** gather virtual memory statistics from the file /proc/vmstat and
 	** store them in binary form (>= kernel 2.6)
 	*/

--- a/photosyst.h
+++ b/photosyst.h
@@ -134,7 +134,8 @@ struct	cpustat {
 	float	lavg1;	/* load average last    minute          */
 	float	lavg5;	/* load average last  5 minutes         */
 	float	lavg15;	/* load average last 15 minutes         */
-	count_t	cfuture[4];	/* reserved for future use	*/
+	count_t	offcpu;	/* number of offlined cpu's 			*/
+	count_t	cfuture[3];	/* reserved for future use	*/
 
 	struct percpu   all;
 	struct percpu   cpu[MAXCPU];

--- a/showlinux.c
+++ b/showlinux.c
@@ -354,6 +354,7 @@ sys_printdef *cplsyspdefs[] = {
 	&syspdef_CPLAVG15,
 	&syspdef_CPLCSW,
 	&syspdef_CPLNUMCPU,
+	&syspdef_CPLOFFCPU,
 	&syspdef_CPLINTR,
 	&syspdef_BLANKBOX,
         0
@@ -1067,7 +1068,8 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
 	                "CPLCSW:6 "
 	                "CPLINTR:5 "
 	                "BLANKBOX:0 "
-	                "CPLNUMCPU:1",
+	                "CPLNUMCPU:1"
+	                "CPLOFFCPU:7",
 			cplsyspdefs, "builtin cplline",
 			sstat, &extra);
                 }

--- a/showlinux.h
+++ b/showlinux.h
@@ -177,6 +177,7 @@ extern sys_printdef syspdef_CPLAVG5;
 extern sys_printdef syspdef_CPLAVG15;
 extern sys_printdef syspdef_CPLCSW;
 extern sys_printdef syspdef_CPLNUMCPU;
+extern sys_printdef syspdef_CPLOFFCPU;
 extern sys_printdef syspdef_CPLINTR;
 extern sys_printdef syspdef_GPUBUS;
 extern sys_printdef syspdef_GPUTYPE;

--- a/showsys.c
+++ b/showsys.c
@@ -1001,6 +1001,22 @@ sysprt_CPLNUMCPU(struct sstat *sstat, extraparam *as, int badness, int *color)
 sys_printdef syspdef_CPLNUMCPU = {"CPLNUMCPU", sysprt_CPLNUMCPU, NULL};
 /*******************************************************************/
 static char *
+sysprt_CPLOFFCPU(struct sstat *sstat, extraparam *as, int badness, int *color)
+{
+        static char buf[16]="offcpu ";
+
+        val2valstr(sstat->cpu.offcpu, buf+7   , 5,0,as->nsecs);
+	/* any offlined CPU is always not expected */
+	if (sstat->cpu.offcpu)
+		*color = COLORCRIT;
+
+        return buf;
+}
+
+sys_printdef syspdef_CPLOFFCPU = {"CPLOFFCPU", sysprt_CPLOFFCPU, NULL};
+
+/*******************************************************************/
+static char *
 sysprt_CPLINTR(struct sstat *sstat, extraparam *as, int badness, int *color) 
 {
         static char buf[16]="intr   ";

--- a/various.c
+++ b/various.c
@@ -805,3 +805,77 @@ set_oom_score_adj(void)
 
 	close(fd);
 }
+
+/* helper function for cpulistnr */
+static const char *next_token(const char *q,  int sep) {
+	if (q)
+		q = strchr(q, sep);
+	if (q)
+		q++;
+
+	return q;
+}
+
+/* helper function for cpulistnr */
+static int next_num(const char *str, char **end, int *result) {
+	if (!str || *str == '\0' || !isdigit(*str))
+		return -1;
+
+	*result = strtoul(str, end, 10);
+	if (str == *end)
+		return -1;
+
+	return 0;
+}
+
+/* parse cpulist and return count
+ * example of this function: "0,2,3", "0,2-3", "0-20:2". */
+int
+cpulistnr(const char *cpulist) {
+	const char *p, *q;
+	char *end = NULL;
+	int count = 0;
+
+	if (!cpulist)
+		return 0;
+
+	q = cpulist;
+	while (p = q, q = next_token(q, ','), p) {
+		int a, b, s;
+		const char *c1, *c2;
+
+		if (next_num(p, &end, &a) != 0)
+			return -1;
+
+		b = a;
+		s = 1;
+		p = end;
+
+		c1 = next_token(p, '-');
+		c2 = next_token(p, ',');
+
+		if (c1 != NULL && (c2 == NULL || c1 < c2)) {
+			if (next_num(c1, &end, &b) != 0)
+				return -1;
+
+			c1 = end && *end ? next_token(end, ':') : NULL;
+			if (c1 != NULL && (c2 == NULL || c1 < c2)) {
+				if (next_num(c1, &end, &s) != 0)
+					return -1;
+
+				if (s == 0)
+					return -1;
+			}
+		}
+
+		if ((a > b))
+			return -1;
+
+		while (a <= b) {
+			count++;
+			a += s;
+		}
+	}
+
+	return count;
+}


### PR DESCRIPTION
 On low probability, a CPU may get offline by hardware reason or manual operation, it should be always unexpected. atop could record this as critical warning.