### PR TITLE
Support second level precision.

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -1060,7 +1060,7 @@ prusage(char *myname)
 	printf("\t\tor\n");
 	printf("Usage: %s -w  file  [-S] [-%c] [interval [samples]]\n",
 					myname, MALLPROC);
-	printf("       %s -r [file] [-b [YYYYMMDD]hhmm] [-e [YYYYMMDD]hhmm] [-flags]\n",
+	printf("       %s -r [file] [-b [YYYYMMDD]hhmm[ss]] [-e [YYYYMMDD]hhmm[ss]] [-flags]\n",
 					myname);
 	printf("\n");
 	printf("\tgeneric flags:\n");

--- a/atopsar.c
+++ b/atopsar.c
@@ -1024,9 +1024,9 @@ pratopsaruse(char *myname)
 	fprintf(stderr,
 		"\t  -R  summarize <cnt> samples into one sample\n");
 	fprintf(stderr,
-		"\t  -b  begin  showing data from  specified time as [YYYYMMDD]hhmm\n");
+		"\t  -b  begin  showing data from  specified time as [YYYYMMDD]hhmm[ss]\n");
 	fprintf(stderr,
-		"\t  -e  finish showing data after specified time as [YYYYMMDD]hhmm\n");
+		"\t  -e  finish showing data after specified time as [YYYYMMDD]hhmm[ss]\n");
 	fprintf(stderr,
 		"\t  -S  print timestamp on every line in case of more "
 		"resources\n");

--- a/man/atop.1
+++ b/man/atop.1
@@ -29,9 +29,9 @@ Writing and reading raw logfiles:
 \-r [
 .I rawfile
 ] [\-b 
-.I [YYYYMMDD]hhmm
+.I [YYYYMMDD]hhmm[ss]
 ] [\-e
-.I [YYYYMMDD]hhmm
+.I [YYYYMMDD]hhmm[ss]
 ] [\-g|\-m|\-d|\-n|\-u|\-p|\-s|\-c|\-v|\-o|\-y|\-Y] [\-C|\-M|\-D|\-N|\-A] [\-fFG1xR] [\-L linelen] [\-Plabel[,label]...]
 .SH DESCRIPTION
 The program
@@ -956,7 +956,7 @@ With the flag
 .B -b
 (begin time) and/or
 .B -e
-(end time) followed by a time argument of the form [YYYYMMDD]hhmm,
+(end time) followed by a time argument of the form [YYYYMMDD]hhmm[ss],
 a certain time period within the raw file can be selected.
 .PP
 Every day at midnight

--- a/man/atopsar.1
+++ b/man/atopsar.1
@@ -11,9 +11,9 @@
 ] [\-R
 .I cnt
 ] [\-b
-.I [YYYYMMDD]hhmm
+.I [YYYYMMDD]hhmm[ss]
 ] [\-e
-.I [YYYYMMDD]hhmm
+.I [YYYYMMDD]hhmm[ss]
 ]
 .br
 .B atopsar
@@ -64,7 +64,7 @@ options
 .B -b
 and
 .B -e
-followed by a time argument of the form [YYYYMMDD]hhmm.
+followed by a time argument of the form [YYYYMMDD]hhmm[ss].
 .PP
 In the second synopsis line,
 .B atopsar

--- a/showgeneric.c
+++ b/showgeneric.c
@@ -1181,7 +1181,7 @@ generic_samp(time_t curtime, int nsecs,
                                 move(statline, 0);
                                 clrtoeol();
                                 printw("Enter new time "
-				       "(format [YYYYMMDD]hhmm): ");
+				       "(format [YYYYMMDD]hhmm[ss]): ");
 
                                 branchtime[0] = '\0';
                                 scanw("%31s\n", branchtime);


### PR DESCRIPTION
When selecting certain time period through -b and -e flags within the raw
file, minute level precision is not enough in some circumstances.

Second level precision is provided, which can be picked up by appending
[YYYYMMDD]hhmmss form to the flags, meanwhile the old form [YYYYMMDD]hhmm
is still retained.