### PR TITLE
CVE: use execvp with a specified path to avoid PATH hijacking

### DIFF
--- a/rawlog.c
+++ b/rawlog.c
@@ -54,6 +54,7 @@
 #include "rawlog.h"
 
 #define	BASEPATH	"/var/log/atop"  
+#define	BINPATH		"/usr/bin/atop"
 
 static int	getrawrec  (int, struct rawrecord *, int);
 static int	getrawsstat(int, struct sstat *, int);
@@ -989,7 +990,7 @@ readchunk(int fd, void *buf, int len)
 static void
 try_other_version(int majorversion, int minorversion)
 {
-	char		tmpbuf[1024], *p;
+	char		tmpbuf[1024];
 	extern char	**argvp;
 	int		fds;
 	struct rlimit	rlimit;
@@ -1000,8 +1001,7 @@ try_other_version(int majorversion, int minorversion)
 	** the current pathname (if any) is stripped off
 	*/
 	snprintf(tmpbuf, sizeof tmpbuf, "%s-%d.%d",
-		(p = strrchr(*argvp, '/')) ? p+1 : *argvp,
-			majorversion, minorversion);
+		BINPATH, majorversion, minorversion);
 
 	fprintf(stderr, "trying to activate %s....\n", tmpbuf);
 


### PR DESCRIPTION
With the upgrade of atop, there are cases when we try to use the new
atop version to read the incompatible log files generated by the old
atop version. The current code uses execvp in try_other_version() to
implement this compatibility mechanism.

However, the execvp is somehow risky. The following is an example.
- Preparation conditions:
  1. Forge a malicious binary named atop-2.4 under /home/test, and
     add it to the global $PATH.
  2. Supposing there's no real /usr/bin/atop-2.4 or other executable
     atop-2.4 except the malicious /home/test/atop-2.4.
  3. Forge a malformed /var/log/atop/atop_2.4, which can do harm to
     current machine if called by the malicious /home/test/atop-2.4.
  4. Update atop to v2.6.
- Reproduce:
  Use the current v2.6's atop to read /var/log/atop/atop_2.4, the code
  will finally find out and call the malicious /home/test/atop-2.4
  (`strace` can show the detail), then trigger the hijacking risk.
- Fix:
  Let's hard-code execvp's first parameter with '/usr/bin/atop' to
  avoid the PATH hijacking.

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>
Reported-by: yangqiushi.george@bytedance.com