### PR TITLE
Add OpenRC init scripts (atop, atopacct)

### DIFF
--- a/atop.rc.openrc
+++ b/atop.rc.openrc
@@ -1,0 +1,8 @@
+#!/sbin/openrc-run
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Resource-specific view of processes"
+pidfile="/var/run/atop.pid"
+command="/usr/share/atop/atop.daily"
+command_background="true"

--- a/atopacct.rc.openrc
+++ b/atopacct.rc.openrc
@@ -1,0 +1,39 @@
+#!/sbin/openrc-run
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+description="Resource-specific view of processes"
+command="/usr/sbin/atopacctd"
+lockfile="/var/lock/subsys/atopacctd"
+
+start_pre() {
+	# Check if process accounting already in use via psacct
+        for PACCTFILE in /var/account/pacct /var/log/pacct ; do
+                if [ -f "${PACCTFILE}" ] ; then
+                        BEFORSIZE=$(stat -c %s "${PACCTFILE}")
+                        AFTERSIZE=$(stat -c %s "${PACCTFILE}")
+
+                        # verify if accounting file grows, so is in use
+                        if [ ${BEFORSIZE} -lt ${AFTERSIZE} ] ; then
+				ewarn "Process accounting already used by psacct!"
+				return 1
+			fi
+		fi
+	done
+
+	checkpath -d -q ${lockfile%/*} || return 1
+}
+
+start() {
+	ebegin "Starting atopacctd"
+	start-stop-daemon --start --exec ${command}
+	touch ${lockfile}
+	eend $?
+}
+
+stop() {
+	ebegin "Stopping atopacctd"
+	start-stop-daemon --stop --exec ${command}
+	rm ${lockfile}
+	eend $?
+}


### PR DESCRIPTION
These have been used for some time in Gentoo but
should work fine on e.g. Alpine too (any distribution
using OpenRC).

Signed-off-by: Sam James <sam@gentoo.org>