### PR TITLE
Calibrate the value of nthr for each process

### DIFF
--- a/photoproc.c
+++ b/photoproc.c
@@ -181,7 +181,7 @@ photoproc(struct tstat *tasklist, int maxtask)
 	DIR		*dirp;
 	struct dirent	*entp;
 	char		origdir[1024], dockstat=0;
-	unsigned long	tval=0;
+	unsigned long	tval=0,cur_nth=0;
 
 	/*
 	** one-time initialization stuff
@@ -234,6 +234,7 @@ photoproc(struct tstat *tasklist, int maxtask)
 
 	while ( (entp = readdir(dirp)) && tval < maxtask )
 	{
+		cur_nth = 0;
 		/*
 		** skip non-numerical names
 		*/
@@ -292,6 +293,7 @@ photoproc(struct tstat *tasklist, int maxtask)
 		netatop_gettask(curtask->gen.tgid, 'g', curtask);
 
 		tval++;		/* increment for process-level info */
+		cur_nth++;
 
 		/*
  		** if needed (when number of threads is larger than 1):
@@ -397,6 +399,7 @@ photoproc(struct tstat *tasklist, int maxtask)
 
 					// all stats read now
 					tval++;	    /* increment thread-level */
+					cur_nth++;
 					if ( chdir("..") == -1); /* thread */
 				}
 
@@ -404,6 +407,7 @@ photoproc(struct tstat *tasklist, int maxtask)
 				if ( chdir("..") == -1); /* leave task */
 			}
 		}
+		curtask->gen.nthr = cur_nth;
 
 		if ( chdir("..") == -1); /* leave process-level directry */
 	}


### PR DESCRIPTION
In current code, we firstly get one process's thread number by
reading "Threads:" from /proc/pid/status; then secondly load each
thread's info into devtstat->taskall by traversing each tid under
/proc/pid/task/. Here, information inconsistency occurs if some
processes frequently creates or deletes threads. For example:
$cat /proc/6/status |grep Threads; sleep 0.1; ls /proc/6/task/ | wc -l
Threads:        70
71

To fix this, calibrate the value of nthr after iterating each
process's threads: re-record the number of threads and assign
to each process's nthr again.

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>