### PR TITLE
Support pgin & pgout

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -702,6 +702,8 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 	dev->mem.zswstored	= cur->mem.zswstored;
 	dev->mem.zswtotpool	= cur->mem.zswtotpool;
 
+	dev->mem.pgouts		= subcount(cur->mem.pgouts,  pre->mem.pgouts);
+	dev->mem.pgins		= subcount(cur->mem.pgins,   pre->mem.pgins);
 	dev->mem.swouts		= subcount(cur->mem.swouts,  pre->mem.swouts);
 	dev->mem.swins		= subcount(cur->mem.swins,   pre->mem.swins);
 	dev->mem.pgscans	= subcount(cur->mem.pgscans, pre->mem.pgscans);
@@ -1516,6 +1518,8 @@ totalsyst(char category, struct sstat *new, struct sstat *tot)
 		tot->mem.shmrss		 = new->mem.shmrss;
 		tot->mem.shmswp		 = new->mem.shmswp;
 
+		tot->mem.pgouts		+= new->mem.pgouts;
+		tot->mem.pgins		+= new->mem.pgins;
 		tot->mem.swouts		+= new->mem.swouts;
 		tot->mem.swins		+= new->mem.swins;
 		tot->mem.pgscans	+= new->mem.pgscans;

--- a/man/atop.1
+++ b/man/atop.1
@@ -1313,7 +1313,9 @@ huge pages (`compact'), the number of NUMA pages migrated (`numamig'), and
 the total number of memory pages migrated succesfully e.g. between
 NUMA nodes or for compaction (`migrate') are shown.
 .br
-Also the number of memory pages the system read from swap space (`swin'),
+Also the number of memory pages the system read from block devices (`pgin'),
+the number of memory pages the system write to block devices (`pgout'),
+the number of memory pages the system read from swap space (`swin'),
 the number of memory pages the system wrote to swap space (`swout'), and
 the number of out-of-memory kills (`oomkill').
 .PP
@@ -2225,7 +2227,9 @@ number of swapouts,
 number of oomkills (-1 when counter not present),
 number of process stalls to run memory compaction,
 number of pages successfully migrated in total, and
-number of NUMA pages migrated.
+number of NUMA pages migrated,
+number of pages read from block devices,
+number of pages written to block devices.
 .TP 9
 .B PSI
 Subsequent fields:

--- a/parseable.c
+++ b/parseable.c
@@ -427,7 +427,7 @@ print_SWP(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 void
 print_PAG(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 {
-	printf("%s %u %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
+	printf("%s %u %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
 			hp,
 			pagesize,
 			ss->mem.pgscans,
@@ -438,7 +438,9 @@ print_PAG(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 			ss->mem.oomkills,
 			ss->mem.compactstall,
 			ss->mem.pgmigrate,
-			ss->mem.numamigrate);
+			ss->mem.numamigrate,
+			ss->mem.pgins,
+			ss->mem.pgouts);
 }
 
 void

--- a/photosyst.c
+++ b/photosyst.c
@@ -589,6 +589,19 @@ photosyst(struct sstat *si)
 			if (nr < 2)		/* headerline ? --> skip */
 				continue;
 
+			/* pgpgin & pgpgout fields in KB from vmstat */
+			if ( strcmp("pgpgin", nam) == EQ)
+			{
+				si->mem.pgins   = cnts[0] * 1024 / pagesize;
+				continue;
+			}
+
+			if ( strcmp("pgpgout", nam) == EQ)
+			{
+				si->mem.pgouts   = cnts[0] * 1024 / pagesize;
+				continue;
+			}
+
 			if ( strcmp("pswpin", nam) == EQ)
 			{
 				si->mem.swins   = cnts[0];

--- a/photosyst.h
+++ b/photosyst.h
@@ -85,7 +85,9 @@ struct	memstat {
 	count_t	compactstall;	// counter for process stalls
 	count_t	pgmigrate;	// counter for migrated successfully (pages)
 	count_t	numamigrate;	// counter for numa migrated (pages)
-	count_t	cfuture[9];	// reserved for future use
+	count_t	pgouts;		// total number of pages written to block device
+	count_t	pgins;		// total number of pages read from block device
+	count_t	cfuture[7];	// reserved for future use
 };
 
 /************************************************************************/

--- a/showlinux.c
+++ b/showlinux.c
@@ -418,6 +418,8 @@ sys_printdef *pagsyspdefs[] = {
 	&syspdef_PAGSWIN,
 	&syspdef_PAGSWOUT,
 	&syspdef_OOMKILLS,
+	&syspdef_PAGPGIN,
+	&syspdef_PAGPGOUT,
 	&syspdef_BLANKBOX,
         0
 };
@@ -1235,8 +1237,8 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
 			"NUMAMIGRATE:5"
 			"PGMIGRATE:6"
 	                "BLANKBOX:0 "
-	                "BLANKBOX:0 "
-	                "BLANKBOX:0 "
+	                "PAGPGIN:7 "
+	                "PAGPGOUT:7 "
 	                "PAGSWIN:5 "
 	                "PAGSWOUT:7 "
 			"OOMKILLS:8 ",
@@ -2195,6 +2197,8 @@ prisyst(struct sstat *sstat, int curline, int nsecs, int avgval,
             sstat->mem.pgsteal    	||
             sstat->mem.allocstall 	||
             sstat->mem.compactstall 	||
+            sstat->mem.pgins      	||
+            sstat->mem.pgouts     	||
             sstat->mem.swins      	||
             sstat->mem.swouts     	||
             sstat->mem.oomkills > 0   	||

--- a/showlinux.h
+++ b/showlinux.h
@@ -245,6 +245,8 @@ extern sys_printdef syspdef_PAGSTALL;
 extern sys_printdef syspdef_PAGCOMPACT;
 extern sys_printdef syspdef_NUMAMIGRATE;
 extern sys_printdef syspdef_PGMIGRATE;
+extern sys_printdef syspdef_PAGPGIN;
+extern sys_printdef syspdef_PAGPGOUT;
 extern sys_printdef syspdef_PAGSWIN;
 extern sys_printdef syspdef_PAGSWOUT;
 extern sys_printdef syspdef_OOMKILLS;

--- a/showsys.c
+++ b/showsys.c
@@ -1633,6 +1633,27 @@ sys_printdef syspdef_PGMIGRATE = {"PGMIGRATE", sysprt_PGMIGRATE, NULL};
 
 /*******************************************************************/
 static char *
+sysprt_PAGPGIN(struct sstat *sstat, extraparam *as, int badness, int *color)
+{
+        static char buf[16]="pgin   ";
+        val2valstr(sstat->mem.pgins, buf+5, 7, as->avgval, as->nsecs);
+        return buf;
+}
+
+sys_printdef syspdef_PAGPGIN = {"PAGPGIN", sysprt_PAGPGIN, NULL};
+/*******************************************************************/
+static char *
+sysprt_PAGPGOUT(struct sstat *sstat, extraparam *as, int badness, int *color)
+{
+        static char buf[16]="pgout  ";
+	*color = -1;
+        val2valstr(sstat->mem.pgouts, buf+6, 6, as->avgval, as->nsecs);
+        return buf;
+}
+
+sys_printdef syspdef_PAGPGOUT = {"PAGPGOUT", sysprt_PAGPGOUT, NULL};
+/*******************************************************************/
+static char *
 sysprt_PAGSWIN(struct sstat *sstat, extraparam *as, int badness, int *color)
 {
         static char buf[16]="swin   ";


### PR DESCRIPTION
Collect pgint & pgout from /proc/vmstat. This counter is provided by
linux block layer, it represents the total number of memory read from/
written to all the block devices.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>