### PR TITLE
Fix disk busy in man page

### DIFF
--- a/man/atop.1
+++ b/man/atop.1
@@ -1343,8 +1343,10 @@ Logical volume/multiple device/disk utilization.
 .br
 Per active unit one line is produced, sorted on unit activity.
 Such line shows the name (e.g. VolGroup00-lvtmp for a logical volume or
-sda for a hard disk), the busy percentage i.e. the portion of time that the
-unit was busy handling requests (`busy'), the number of read requests issued
+sda for a hard disk), the percentage of elapsed time during which I/O requests
+were issued to the device (`busy') (note that for devices serving requests in
+parallel, such as RAID arrays, SSD and NVMe, this number does not reflect their
+performance limits), the number of read requests issued
 (`read'), the number of write requests issued (`write'),
 the number of discard requests issued (`discrd') if supported by kernel version,
 the number of KiBytes per read (`KiB/r'), 


### PR DESCRIPTION
Reference source code from Linux:
https://github.com/torvalds/linux/blob/master/block/blk-core.c

void update_io_ticks(struct block_device *part, unsigned long now, bool end)
{
	unsigned long stamp;
again:
	stamp = READ_ONCE(part->bd_stamp);
	if (unlikely(time_after(now, stamp))) {
		if (likely(cmpxchg(&part->bd_stamp, stamp, now) == stamp))
			__part_stat_add(part, io_ticks, end ? now - stamp : 1);
	}
	if (part->bd_partno) {
		part = bdev_whole(part);
		goto again;
	}
}

The io_ticks field records the elapsed time during which I/O requests
were issued to the device. From this design, one or more I/O requests
may occurs in the same tick, so this number does not reflect the
performance limits of mordern SSD/NVMe.

atop reads this counter and calculates the percentage, fix the man
page to introduce this.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>