### PR TITLE
showhdrline: fix OOB access when COLS is too small

### DIFF
--- a/showprocs.c
+++ b/showprocs.c
@@ -190,6 +190,12 @@ getspacings(proc_printpair* elemptr)
                 return spacings;
         }
 
+        // avoid division by 0
+        if (nitems==1)
+        {
+                spacings[0]=0;
+                return spacings;
+        }
 
         /* fixed columns, spread whitespace over columns */
         double over=(0.0+maxw-col)/(nitems-1);
@@ -278,7 +284,7 @@ showhdrline(proc_printpair* elemptr, int curlist, int totlist,
                 {
                         sprintf(buf+col, "%*s", allign+pagindiclen, pagindic);
                 }
-                else
+                else if (col+allign >= 0)
                 {    // allign by removing from the right
                         sprintf(buf+col+allign, "%s", pagindic);
                 }


### PR DESCRIPTION
- How to reproduce:
Drag the window to the far right, a "Segmentation fault (core dumped)"
message occurs.

- Debug:
Add some print values, saying COLS=2, thus maxw.

After getspacings(), elemptr becomes a NULL array again: maxw is too
small, so after nitems times of memmove(), newelems is NULL.

Then back to showhdrline(), as each curelem.f is zero, no chead is
assigned to buf and col is still zero. However, after the calculation:
allign=COLS-col-pagindiclen;//align=2-0-4=-2 < 0, previous code jumps
to sprintf(buf+col+allign, "%s", pagindic), which triggers
out-of-bounds access as col+allign = -2 < 0.

- Fix:
Fix this by judging if (col+allign >= 0) before jumping to avoid the
OOB access.

Reported-by: Qi Zheng <zhengqi.arch@bytedance.com>
Signed-off-by: Fei Li <lifei.shirley@bytedance.com>