### PR TITLE
supplement tcpsock and udpsock memory consumption

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -705,6 +705,9 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 	dev->mem.zswstored	= cur->mem.zswstored;
 	dev->mem.zswtotpool	= cur->mem.zswtotpool;
 
+	dev->mem.tcpsock	= cur->mem.tcpsock;
+	dev->mem.udpsock	= cur->mem.udpsock;
+
 	dev->mem.pgouts		= subcount(cur->mem.pgouts,  pre->mem.pgouts);
 	dev->mem.pgins		= subcount(cur->mem.pgins,   pre->mem.pgins);
 	dev->mem.swouts		= subcount(cur->mem.swouts,  pre->mem.swouts);
@@ -1520,6 +1523,9 @@ totalsyst(char category, struct sstat *new, struct sstat *tot)
 		tot->mem.shmem		 = new->mem.shmem;
 		tot->mem.shmrss		 = new->mem.shmrss;
 		tot->mem.shmswp		 = new->mem.shmswp;
+
+		tot->mem.tcpsock	= new->mem.tcpsock;
+		tot->mem.udpsock	= new->mem.udpsock;
 
 		tot->mem.pgouts		+= new->mem.pgouts;
 		tot->mem.pgins		+= new->mem.pgins;

--- a/man/atop.1
+++ b/man/atop.1
@@ -1315,6 +1315,8 @@ NUMA nodes or for compaction (`migrate') are shown.
 .br
 Also the number of memory pages the system read from block devices (`pgin'),
 the number of memory pages the system wrote to block devices (`pgout'),
+the number of memory pages allocated by TCP sockets (`tcpsock`),
+the number of memory pages allocated by UDP sockets (`udpsock`),
 the number of memory pages the system read from swap space (`swin'),
 the number of memory pages the system wrote to swap space (`swout'), and
 the number of out-of-memory kills (`oomkill').
@@ -2235,7 +2237,9 @@ number of process stalls to run memory compaction,
 number of pages successfully migrated in total,
 number of NUMA pages migrated,
 number of pages read from block devices, and
-number of pages written to block devices.
+number of pages written to block devices,
+number of pages allocated by TCP sockets,
+number of pages allocated by UDP sockets.
 .TP 9
 .B PSI
 Subsequent fields:

--- a/parseable.c
+++ b/parseable.c
@@ -427,7 +427,7 @@ print_SWP(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 void
 print_PAG(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 {
-	printf("%s %u %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
+	printf("%s %u %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
 			hp,
 			pagesize,
 			ss->mem.pgscans,
@@ -440,7 +440,9 @@ print_PAG(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 			ss->mem.pgmigrate,
 			ss->mem.numamigrate,
 			ss->mem.pgins,
-			ss->mem.pgouts);
+			ss->mem.pgouts,
+			ss->mem.tcpsock,
+			ss->mem.udpsock);
 }
 
 void

--- a/photosyst.h
+++ b/photosyst.h
@@ -60,6 +60,8 @@ struct	memstat {
 	count_t	allocstall;	// try to free pages forced
 	count_t	swouts;		// number of pages swapped out
 	count_t	swins;		// number of pages swapped in
+	count_t	tcpsock;	// number of pages allocated by TCP sockets
+	count_t	udpsock;	// number of pages allocated by UDP sockets
 
 	count_t	commitlim;	// commit limit in pages
 	count_t	committed;	// number of reserved pages
@@ -87,7 +89,7 @@ struct	memstat {
 	count_t	numamigrate;	// counter for numa migrated (pages)
 	count_t	pgouts;		// total number of pages written to block device
 	count_t	pgins;		// total number of pages read from block device
-	count_t	cfuture[7];	// reserved for future use
+	count_t	cfuture[5];	// reserved for future use
 };
 
 /************************************************************************/

--- a/showlinux.c
+++ b/showlinux.c
@@ -420,6 +420,8 @@ sys_printdef *pagsyspdefs[] = {
 	&syspdef_OOMKILLS,
 	&syspdef_PAGPGIN,
 	&syspdef_PAGPGOUT,
+	&syspdef_TCPSOCK,
+	&syspdef_UDPSOCK,
 	&syspdef_BLANKBOX,
         0
 };
@@ -1223,10 +1225,10 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
 	                "PAGCOMPACT:5 "
 			"NUMAMIGRATE:5"
 			"PGMIGRATE:6"
-	                "BLANKBOX:0 "
 	                "PAGPGIN:7 "
 	                "PAGPGOUT:7 "
-	                "BLANKBOX:0 "
+	                "TCPSOCK:7 "
+	                "UDPSOCK:5 "
 	                "PAGSWIN:5 "
 	                "PAGSWOUT:8 "
 			"OOMKILLS:9 ",
@@ -2191,6 +2193,8 @@ prisyst(struct sstat *sstat, int curline, int nsecs, int avgval,
             sstat->mem.compactstall 	||
             sstat->mem.pgins      	||
             sstat->mem.pgouts     	||
+            sstat->mem.tcpsock     	||
+            sstat->mem.udpsock     	||
             sstat->mem.swins      	||
             sstat->mem.swouts     	||
             sstat->mem.oomkills > 0   	||

--- a/showlinux.h
+++ b/showlinux.h
@@ -247,6 +247,8 @@ extern sys_printdef syspdef_NUMAMIGRATE;
 extern sys_printdef syspdef_PGMIGRATE;
 extern sys_printdef syspdef_PAGPGIN;
 extern sys_printdef syspdef_PAGPGOUT;
+extern sys_printdef syspdef_TCPSOCK;
+extern sys_printdef syspdef_UDPSOCK;
 extern sys_printdef syspdef_PAGSWIN;
 extern sys_printdef syspdef_PAGSWOUT;
 extern sys_printdef syspdef_OOMKILLS;

--- a/showsys.c
+++ b/showsys.c
@@ -1653,6 +1653,26 @@ sysprt_PAGPGOUT(struct sstat *sstat, extraparam *as, int badness, int *color)
 sys_printdef syspdef_PAGPGOUT = {"PAGPGOUT", sysprt_PAGPGOUT, NULL};
 /*******************************************************************/
 static char *
+sysprt_TCPSOCK(struct sstat *sstat, extraparam *as, int badness, int *color)
+{
+        static char buf[16]="tcpsock  ";
+        val2valstr(sstat->mem.tcpsock, buf+8, 4, as->avgval, as->nsecs);
+        return buf;
+}
+
+sys_printdef syspdef_TCPSOCK = {"TCPSOCK", sysprt_TCPSOCK, NULL};
+/*******************************************************************/
+static char *
+sysprt_UDPSOCK(struct sstat *sstat, extraparam *as, int badness, int *color)
+{
+        static char buf[16]="udpsock  ";
+        val2valstr(sstat->mem.udpsock, buf+8, 4, as->avgval, as->nsecs);
+        return buf;
+}
+
+sys_printdef syspdef_UDPSOCK = {"UDPSOCK", sysprt_UDPSOCK, NULL};
+/*******************************************************************/
+static char *
 sysprt_PAGSWIN(struct sstat *sstat, extraparam *as, int badness, int *color)
 {
         static char buf[16]="swin   ";


### PR DESCRIPTION
In some production cases, tcp socket consumes lots of memory, which
has no intersection with the statistics in /proc/meminfo file.

Considering the current code does not collect and record the tcpsock
or udpsock statistics reported via /proc/net/sockstat, supplement
the following two to help locate memory consumption issues:
- tcpsock, number of pages allocated by TCP sockets
- udpsock, number of pages allocated by UDP sockets

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>