### PR TITLE
Fix compiling error with -DHTTPSTATS

### DIFF
--- a/prev/photosyst_27.h
+++ b/prev/photosyst_27.h
@@ -324,7 +324,7 @@ struct wwwstat_27 {
 };
 
 #if	HTTPSTATS
-int	getwwwstat(unsigned short, struct wwwstat_27 *);
+int	getwwwstat_27(unsigned short, struct wwwstat_27 *);
 #endif
 /************************************************************************/
 struct pergpu_27 {


### PR DESCRIPTION
Fix compiling error like this:
In file included from atopconvert.c:77:
prev/photosyst_27.h:327:5: error: conflicting types for ‘getwwwstat’
  327 | int getwwwstat(unsigned short, struct wwwstat_27 *);
      |     ^~~~~~~~~~
In file included from atopconvert.c:52:
photosyst.h:361:5: note: previous declaration of ‘getwwwstat’ was here
  361 | int getwwwstat(unsigned short, struct wwwstat *);
      |     ^~~~~~~~~~

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>