### PR TITLE
supplement inflight I/O requests

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -1026,6 +1026,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 		                                  pre->dsk.dsk[j].nwrite);
 		dev->dsk.dsk[i].nwsect = subcount(cur->dsk.dsk[i].nwsect,
 		                                  pre->dsk.dsk[j].nwsect);
+		dev->dsk.dsk[i].inflight  = cur->dsk.dsk[i].inflight;
 		dev->dsk.dsk[i].io_ms  = subcount(cur->dsk.dsk[i].io_ms,
 		                                  pre->dsk.dsk[j].io_ms);
 		dev->dsk.dsk[i].avque  = subcount(cur->dsk.dsk[i].avque,

--- a/man/atop.1
+++ b/man/atop.1
@@ -1376,6 +1376,7 @@ the number of KiBytes per write (`KiB/w'),
 the number of KiBytes per discard (`KiB/d') if supported by kernel version,
 the number of MiBytes per second throughput for reads (`MBr/s'), 
 the number of MiBytes per second throughput for writes (`MBw/s'), 
+requests issued to the device driver but not completed (`inflt'),
 the average queue depth (`avq')
 and the average number of milliseconds needed by a request (`avio')
 for seek, latency and data transfer.

--- a/photosyst.c
+++ b/photosyst.c
@@ -1253,12 +1253,13 @@ photosyst(struct sstat *si)
 		{
 			nr = sscanf(linebuf,
 			      "%*d %*d %*d %255s %lld %*d %lld %*d "
-			      "%lld %*d %lld %*d %*d %lld %lld",
+			      "%lld %*d %lld %*d %lld %lld %lld",
 			        diskname,
 				&(si->dsk.dsk[i].nread),
 				&(si->dsk.dsk[i].nrsect),
 				&(si->dsk.dsk[i].nwrite),
 				&(si->dsk.dsk[i].nwsect),
+				&(si->dsk.dsk[i].inflight),
 				&(si->dsk.dsk[i].io_ms),
 				&(si->dsk.dsk[i].avque) );
 
@@ -1267,7 +1268,7 @@ photosyst(struct sstat *si)
 			** or just one of the partitions of a disk (to be
 			** skipped)
 			*/
-			if (nr == 7)	/* full stats-line ? */
+			if (nr == 8)	/* full stats-line ? */
 			{
 				if ( isdisk(0, 0, diskname,
 				                 &(si->dsk.dsk[i]),
@@ -1310,15 +1311,15 @@ photosyst(struct sstat *si)
 			      "%d %d %255s "		// ident
                               "%lld %*d %lld %*d "	// reads
 			      "%lld %*d %lld %*d "	// writes
-			      "%*d %lld %lld "		// misc
+			      "%lld %lld %lld "		// misc
 			      "%lld %*d %lld %*d",	// discards
 				&major, &minor, diskname,
 				&tmpdsk.nread,  &tmpdsk.nrsect,
 				&tmpdsk.nwrite, &tmpdsk.nwsect,
-				&tmpdsk.io_ms,  &tmpdsk.avque,
+				&tmpdsk.inflight, &tmpdsk.io_ms, &tmpdsk.avque,
 				&tmpdsk.ndisc,  &tmpdsk.ndsect);
 
-			if (nr >= 9)	/* full stats-line ? */
+			if (nr >= 10)	/* full stats-line ? */
 			{
 				/*
   				** when no transfers issued, skip disk (partition)

--- a/photosyst.h
+++ b/photosyst.h
@@ -190,16 +190,17 @@ struct	cpustat {
 /************************************************************************/
 
 struct	perdsk {
-        char	name[MAXDKNAM];	/* empty string for last        */
-        count_t	nread;	/* number of read  transfers            */
-        count_t	nrsect;	/* number of sectors read               */
-        count_t	nwrite;	/* number of write transfers            */
-        count_t	nwsect;	/* number of sectors written            */
-        count_t	io_ms;	/* number of millisecs spent for I/O    */
-        count_t	avque;	/* average queue length                 */
-        count_t	ndisc;	/* number of discards (-1 = unavailable)*/
-        count_t	ndsect;	/* number of sectors discarded          */
-	count_t	cfuture[2];	/* reserved for future use	*/
+        char	name[MAXDKNAM];	/* empty string for last		*/
+        count_t	nread;		/* number of read  transfers		*/
+        count_t	nrsect;		/* number of sectors read		*/
+        count_t	nwrite;		/* number of write transfers		*/
+        count_t	nwsect;		/* number of sectors written		*/
+        count_t	inflight;	/* number of inflight I/O		*/
+        count_t	io_ms;		/* number of millisecs spent for I/O	*/
+        count_t	avque;		/* average queue length			*/
+        count_t	ndisc;		/* number of discards (-1 = unavailable)*/
+        count_t	ndsect;		/* number of sectors discarded		*/
+        count_t	cfuture[1];	/* reserved for future use		*/
 };
 
 struct dskstat {

--- a/showlinux.c
+++ b/showlinux.c
@@ -494,6 +494,7 @@ sys_printdef *dsksyspdefs[] = {
 	&syspdef_DSKKBPERRD,
 	&syspdef_DSKKBPERWR,
 	&syspdef_DSKKBPERDS,
+	&syspdef_DSKINFLIGHT,
 	&syspdef_DSKAVQUEUE,
 	&syspdef_DSKAVIO,
 	&syspdef_BLANKBOX,
@@ -1291,6 +1292,7 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
 	                "DSKKBPERDS:4 "
                         "DSKMBPERSECRD:6 "
                         "DSKMBPERSECWR:6 "
+	                "DSKINFLIGHT:1 "
 	                "DSKAVQUEUE:1 "
 	                "DSKAVIO:6",
 			dsksyspdefs, "builtin dskline",

--- a/showlinux.h
+++ b/showlinux.h
@@ -276,6 +276,7 @@ extern sys_printdef syspdef_DSKMBPERSECWR;
 extern sys_printdef syspdef_DSKKBPERRD;
 extern sys_printdef syspdef_DSKKBPERWR;
 extern sys_printdef syspdef_DSKKBPERDS;
+extern sys_printdef syspdef_DSKINFLIGHT;
 extern sys_printdef syspdef_DSKAVQUEUE;
 extern sys_printdef syspdef_DSKAVIO;
 extern sys_printdef syspdef_NETTRANSPORT;

--- a/showsys.c
+++ b/showsys.c
@@ -2404,6 +2404,18 @@ sysprt_DSKMBPERSECRD(struct sstat *sstat, extraparam *as, int badness, int *colo
 sys_printdef syspdef_DSKMBPERSECRD = {"DSKMBPERSECRD", sysprt_DSKMBPERSECRD, NULL};
 /*******************************************************************/
 static char *
+sysprt_DSKINFLIGHT(struct sstat *sstat, extraparam *as, int badness, int *color)
+{
+        static char    buf[16]="inflt  ";
+        struct perdsk  *dp = &(as->perdsk[as->index]);
+
+        val2valstr(dp->inflight, buf+6, 6, 0, 0);
+        return buf;
+}
+
+sys_printdef syspdef_DSKINFLIGHT = {"DSKINFLIGHT", sysprt_DSKINFLIGHT, NULL};
+/*******************************************************************/
+static char *
 sysprt_DSKAVQUEUE(struct sstat *sstat, extraparam *as, int badness, int *color) 
 {
         static char	buf[16]="avq  ";


### PR DESCRIPTION
Inflight I/O requests count I/O requests issued to the device driver but
have not yet completed, which are useful to analyze system I/O status.
More than this, since plenty of processes remain in D status for a long time
come from I/O troubles, inflight I/O values also help to examine these processes.

Signed-off-by: Teng Hu <huteng.ht@bytedance.com>