### PR TITLE
Add macro protection in header files

### DIFF
--- a/acctproc.h
+++ b/acctproc.h
@@ -21,6 +21,10 @@
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ** See the GNU General Public License for more details.
 */
+
+#ifndef __ACCTPROC__
+#define __ACCTPROC__
+
 int 		acctswon(void);
 void		acctswoff(void);
 unsigned long 	acctprocnt(void);
@@ -156,3 +160,5 @@ struct acct_v3
 	comp_t		ac_swaps;		/* Number of Swaps */
 	char		ac_comm[ACCT_COMM];	/* Command Name */
 };
+
+#endif

--- a/atop.h
+++ b/atop.h
@@ -21,6 +21,9 @@
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ** See the GNU General Public License for more details.
 */
+#ifndef __ATOP__
+#define __ATOP__
+
 #define	EQ		0
 #define SECONDSINDAY	86400
 #define RAWNAMESZ	256
@@ -207,3 +210,5 @@ void		netatop_exithash(char);
 void		netatop_exitfind(unsigned long, struct tstat *, struct tstat *);
 void		set_oom_score_adj(void);
 int		run_in_guest(void);
+
+#endif

--- a/atopacctd.h
+++ b/atopacctd.h
@@ -26,6 +26,9 @@
 ** --------------------------------------------------------------------------
 */
 
+#ifndef __ATOPACCTD__
+#define __ATOPACCTD__
+
 /*
 ** keys to access the semaphores
 */
@@ -61,3 +64,5 @@
 						// sequence and MAXSHADOWREC
 
 #define MAXSHADOWREC	10000 	// number of accounting records per shadow file
+
+#endif

--- a/ifprop.h
+++ b/ifprop.h
@@ -26,6 +26,9 @@
 ** --------------------------------------------------------------------------
 */
 
+#ifndef __IFPROP__
+#define __IFPROP__
+
 struct ifprop	{
 	char		type;		/* type: 'e' - ethernet		*/
 					/*       'w' - wireless  	*/
@@ -39,3 +42,5 @@ struct ifprop	{
 
 int 	getifprop(struct ifprop *);
 void 	initifprop(void);
+
+#endif

--- a/mkdate
+++ b/mkdate
@@ -4,4 +4,7 @@
 #
 CURDATE=$(date +%Y/%m/%d\ %H:%M:%S)
 
-echo "#define	ATOPDATE	\"$CURDATE\""	> versdate.h
+echo "#ifndef __ATOP_VERSDATA__"	> versdate.h
+echo "#define __ATOP_VERSDATA__"	>> versdate.h
+echo "#define	ATOPDATE	\"$CURDATE\""	>> versdate.h
+echo "#endif"	>> versdate.h

--- a/netatop.h
+++ b/netatop.h
@@ -26,6 +26,9 @@
 ** --------------------------------------------------------------------------
 */
 
+#ifndef __NETATOP__
+#define __NETATOP__
+
 #define	COMLEN	16
 
 struct taskcount {
@@ -73,3 +76,5 @@ struct netpertask {
 
 // get counters for thread:  input is 'id' (tid)
 #define NETATOP_GETCNT_PID 	(NETATOP_BASE_CTL+5)
+
+#endif

--- a/netatopd.h
+++ b/netatopd.h
@@ -26,6 +26,9 @@
 ** --------------------------------------------------------------------------
 */
 
+#ifndef __NETATOPD__
+#define __NETATOPD__
+
 #define SEMAKEY         1541961
 
 #define NETEXITFILE     "/var/run/netatop.log"
@@ -38,3 +41,5 @@ struct naheader {
         u_int16_t	ntplen;	// length of netpertask structure
         pid_t    	mypid;	// PID of netatopd itself
 };
+
+#endif

--- a/netstats.h
+++ b/netstats.h
@@ -26,6 +26,9 @@
 ** --------------------------------------------------------------------------
 */
 
+#ifndef __NETSTATS__
+#define __NETSTATS__
+
 /*
 ** structures defined from the output of /proc/net/snmp and /proc/net/snmp6
 */
@@ -167,3 +170,5 @@ struct udpv6_stats {
 	count_t Udp6InErrors;
 	count_t Udp6OutDatagrams;
 };
+
+#endif

--- a/parseable.h
+++ b/parseable.h
@@ -25,7 +25,12 @@
 ** Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 ** --------------------------------------------------------------------------
 */
+#ifndef __PARSEABLE__
+#define __PARSEABLE__
+
 int 	parsedef(char *);
 char	parseout(time_t, int,
 		struct devtstat *, struct sstat *,
 		int, unsigned int, char);
+
+#endif

--- a/photoproc.h
+++ b/photoproc.h
@@ -23,6 +23,9 @@
 ** See the GNU General Public License for more details.
 */
 
+#ifndef __PHOTOPROC__
+#define __PHOTOPROC__
+
 #define	PNAMLEN		15
 #define	CMDLEN		255
 #define	CGRLEN		64
@@ -198,3 +201,5 @@ void		deviattask(struct tstat *, unsigned long,
 
 unsigned long	photoproc(struct tstat *, int);
 unsigned long	counttasks(void);
+
+#endif

--- a/rawlog.h
+++ b/rawlog.h
@@ -26,6 +26,9 @@
 ** --------------------------------------------------------------------------
 */
 
+#ifndef __RAWLOG__
+#define __RAWLOG__
+
 /*
 ** structure describing the raw file contents
 **
@@ -90,3 +93,5 @@ struct rawrecord {
 	unsigned int	noverflow;	/* number of overflow processes */
 	unsigned int	ifuture[6];	/* future use                   */
 };
+
+#endif

--- a/showgeneric.h
+++ b/showgeneric.h
@@ -21,6 +21,9 @@
 ** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 ** See the GNU General Public License for more details.
 */
+#ifndef __SHOWGENERIC__
+#define __SHOWGENERIC__
+
 #define USERSTUB	9999999
 #define MAXUSERSEL	64
 #define MAXPID		32
@@ -161,3 +164,5 @@ int	prisyst(struct sstat  *, int, int, int, int, struct sselection *,
 int	priproc(struct tstat  **, int, int, int, int, int, char, char,
 	        struct syscap *, int, int);
 void	priphead(int, int, char *, char *, char, count_t);
+
+#endif

--- a/showlinux.h
+++ b/showlinux.h
@@ -34,6 +34,10 @@
 ** Initial
 **
 */
+
+#ifndef __SHOWLINUX__
+#define __SHOWLINUX__
+
 #define MAXITEMS 80    /* The maximum number of items per line */
 
 /*
@@ -466,3 +470,5 @@ extern char *procprt_TCPSASZ_e(struct tstat *, int, int);
 extern char *procprt_TCPRASZ_e(struct tstat *, int, int);
 extern char *procprt_UDPSASZ_e(struct tstat *, int, int);
 extern char *procprt_UDPRASZ_e(struct tstat *, int, int);
+
+#endif

--- a/version.h
+++ b/version.h
@@ -1,1 +1,6 @@
+#ifndef __ATOP_VERSION__
+#define __ATOP_VERSION__
+
 #define	ATOPVERS	"2.7.1"
+
+#endif


### PR DESCRIPTION
Add following codes to protect header files:
 #ifndef __XXX__
 #define __XXX__
 ...
 #endif

Currently building atop without these macros works fine. To avoid building error in the future, add these in each header files.

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>