### PR TITLE
photosys.c: correct the numa number for NUM and NUC

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -742,6 +742,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 
 	for (i=0; i < dev->memnuma.nrnuma; i++)
 	{
+		dev->memnuma.numa[i].numanr      = cur->memnuma.numa[i].numanr;
 		dev->memnuma.numa[i].totmem      = cur->memnuma.numa[i].totmem;
 		dev->memnuma.numa[i].freemem     = cur->memnuma.numa[i].freemem;
 		dev->memnuma.numa[i].filepage    = cur->memnuma.numa[i].filepage;
@@ -762,6 +763,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 		for (i=0; i < dev->cpunuma.nrnuma; i++)
 		{
 			dev->cpunuma.numa[i].nrcpu  = cur->cpunuma.numa[i].nrcpu;
+			dev->cpunuma.numa[i].numanr = cur->cpunuma.numa[i].numanr;
 
 			dev->cpunuma.numa[i].utime  = subcount(cur->cpunuma.numa[i].utime,
 								pre->cpunuma.numa[i].utime);

--- a/json.c
+++ b/json.c
@@ -70,6 +70,7 @@ static void json_print_NFS();
 static void json_print_NET();
 static void json_print_IFB();
 static void json_print_NUM();
+static void json_print_NUC();
 static void json_print_LLC();
 static void json_print_PRG();
 static void json_print_PRC();
@@ -106,6 +107,7 @@ static struct labeldef	labeldef[] = {
 	{ "NET",	0,	json_print_NET },
 	{ "IFB",	0,	json_print_IFB },
 	{ "NUM",	0,	json_print_NUM },
+	{ "NUC",	0,	json_print_NUC },
 	{ "LLC",	0,	json_print_LLC },
 
 	{ "PRG",	0,	json_print_PRG },
@@ -813,13 +815,14 @@ static void json_print_NUM(char *hp, struct sstat *ss, struct tstat *ps, int nac
 {
 	register int i;
 
-        printf(", %s: [", hp);
+	printf(", %s: [", hp);
 
 	for (i = 0; i < ss->memnuma.nrnuma; i++) {
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"frag\": \"%f\", "
+		printf("{\"numanr\": \"%d\", "
+			"\"frag\": \"%f\", "
 			"\"totmem\": %lld, "
 			"\"freemem\": %lld, "
 			"\"active\": %lld, "
@@ -830,6 +833,7 @@ static void json_print_NUM(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"slabreclaim\": %lld, "
 			"\"shmem\": %lld, "
 			"\"tothp\": %lld}",
+			ss->memnuma.numa[i].numanr,
 			ss->memnuma.numa[i].frag * 100.0,
 			ss->memnuma.numa[i].totmem * pagesize,
 			ss->memnuma.numa[i].freemem * pagesize,
@@ -841,6 +845,41 @@ static void json_print_NUM(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			ss->memnuma.numa[i].slabreclaim * pagesize,
 			ss->memnuma.numa[i].shmem * pagesize,
 			ss->memnuma.numa[i].tothp * ss->mem.hugepagesz);
+	}
+
+	printf("]");
+}
+
+static void json_print_NUC(char *hp, struct sstat *ss, struct tstat *ps, int nact)
+{
+	register int i;
+
+	printf(", %s: [", hp);
+
+	for (i = 0; i < ss->cpunuma.nrnuma; i++) {
+		if (i > 0) {
+			printf(", ");
+		}
+		printf("{\"numanr\": \"%d\", "
+			"\"stime\": %lld, "
+			"\"utime\": %lld, "
+			"\"ntime\": %lld, "
+			"\"itime\": %lld, "
+			"\"wtime\": %lld, "
+			"\"Itime\": %lld, "
+			"\"Stime\": %lld, "
+			"\"steal\": %lld, "
+			"\"guest\": %lld}",
+			ss->cpunuma.numa[i].numanr,
+			ss->cpunuma.numa[i].stime,
+			ss->cpunuma.numa[i].utime,
+			ss->cpunuma.numa[i].ntime,
+			ss->cpunuma.numa[i].itime,
+			ss->cpunuma.numa[i].wtime,
+			ss->cpunuma.numa[i].Itime,
+			ss->cpunuma.numa[i].Stime,
+			ss->cpunuma.numa[i].steal,
+			ss->cpunuma.numa[i].guest);
 	}
 
 	printf("]");

--- a/parseable.c
+++ b/parseable.c
@@ -657,7 +657,7 @@ print_NUM(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 	for (i=0; i < ss->memnuma.nrnuma; i++)
 	{
 		printf(	"%s %d %u %.0f %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
-			hp, i,
+			hp, ss->memnuma.numa[i].numanr,
 			pagesize,
 			ss->memnuma.numa[i].frag * 100.0,
 			ss->memnuma.numa[i].totmem,
@@ -681,7 +681,7 @@ print_NUC(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 	for (i=0; i < ss->cpunuma.nrnuma; i++)
 	{
 		printf(	"%s %d %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
-			hp, i,
+			hp, ss->cpunuma.numa[i].numanr,
 	        	ss->cpunuma.numa[i].nrcpu,
 	        	ss->cpunuma.numa[i].stime,
         		ss->cpunuma.numa[i].utime,

--- a/photosyst.c
+++ b/photosyst.c
@@ -875,6 +875,7 @@ photosyst(struct sstat *si)
 					if (cnts[0] != j)
 						continue;
 
+					si->memnuma.numa[j].numanr = j;
 					if ( strcmp("MemTotal:", nam) == EQ)
 						si->memnuma.numa[j].totmem = cnts[1]*1024/pagesize;
 					else if ( strcmp("MemFree:", nam) == EQ)
@@ -1018,6 +1019,7 @@ photosyst(struct sstat *si)
 					si->cpunuma.numa[j].guest += si->cpu.cpu[i].guest;
 				}
 			}
+			si->cpunuma.numa[j].numanr = j;
 		}
 
 		free(line);

--- a/photosyst.h
+++ b/photosyst.h
@@ -96,6 +96,7 @@ struct	memstat {
 /************************************************************************/
 
 struct	mempernuma {
+	int	numanr;
 	float	frag;		// fragmentation level for this numa
 	count_t	totmem;		// number of physical pages for this numa
 	count_t	freemem;	// number of free     pages for this numa
@@ -117,6 +118,7 @@ struct	memnuma {
 };
 
 struct	cpupernuma {
+	int	numanr;
 	count_t	nrcpu;		// number of cpu's
 	count_t	stime;		// accumulate system  time in clock ticks for per numa
 	count_t	utime;		// accumulate user    time in clock ticks for per numa

--- a/showsys.c
+++ b/showsys.c
@@ -1765,7 +1765,7 @@ sysprt_NUMANR(struct sstat *sstat, extraparam *as, int badness, int *color)
 {
 	static char buf[16];
 	*color = -1;
-	sprintf(buf, "numanode%04d", as->index);
+	sprintf(buf, "numanode%04d", sstat->memnuma.numa[as->index].numanr);
 	return buf;
 }
 
@@ -1970,7 +1970,7 @@ sysprt_NUMACPUWAIT(struct sstat *sstat, extraparam *as, int badness, int *color)
 	static char buf[15];
 
 	sprintf(buf, "nod%03d w%3.0f%%",
-		as->index,
+		sstat->cpunuma.numa[as->index].numanr,
 		(sstat->cpunuma.numa[as->index].wtime * 100.0) / as->percputot);
 	return buf;
 }


### PR DESCRIPTION
Current code uses array index to store the numa number, which may sort the numanr to a wrong value after the qsort() funtion in generic_samp().

Fix this by re-adding the 'numanr' member for struct mempernuma and cpupernuma to store the correct numa number. The permanent 'numanr' member can guarantee the numa number from adjusting after qsort(), while the qsort() function can continue working by sorting NUM from small to large according to free memory, and sorting NUC from small to large according to idle cpu.

Besides, add NUC for JSON output.

Fixes: 1fbda3f1081a ("Additions to NUMA counters")
Reported-by: Qi Zheng <zhengqi.arch@bytedance.com>
Signed-off-by: Fei Li <lifei.shirley@bytedance.com>