### PR TITLE
Add nvcsw and nivcsw for each process

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -529,6 +529,18 @@ calcdiff(struct tstat *devstat, const struct tstat *curstat,
 	devstat->cpu.blkdelay  =
 		subcount(curstat->cpu.blkdelay, prestat->cpu.blkdelay);
 
+	if (curstat->cpu.nvcsw >= prestat->cpu.nvcsw)
+		devstat->cpu.nvcsw  =
+			subcount(curstat->cpu.nvcsw, prestat->cpu.nvcsw);
+	else
+		devstat->cpu.nvcsw = curstat->cpu.nvcsw;
+
+	if (curstat->cpu.nivcsw >= prestat->cpu.nivcsw)
+		devstat->cpu.nivcsw =
+			subcount(curstat->cpu.nivcsw, prestat->cpu.nivcsw);
+	else
+		devstat->cpu.nivcsw = curstat->cpu.nivcsw;
+
 	devstat->dsk.rio    =
 		subcount(curstat->dsk.rio, prestat->dsk.rio);
 	devstat->dsk.rsz    =

--- a/json.c
+++ b/json.c
@@ -1028,6 +1028,8 @@ static void json_print_PRC(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"isproc\": %d, "
 			"\"rundelay\": %lld, "
 			"\"blkdelay\": %lld, "
+			"\"nvcsw\": %llu, "
+			"\"nivcsw\": %llu, "
 			"\"sleepavg\": %d}",
 			ps->gen.pid,
 			ps->cpu.utime,
@@ -1039,6 +1041,8 @@ static void json_print_PRC(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			!!ps->gen.isproc,
 			ps->cpu.rundelay/1000000,
 			ps->cpu.blkdelay*1000/hertz,
+			ps->cpu.nvcsw,
+			ps->cpu.nivcsw,
 			ps->cpu.sleepavg);
 	}
 

--- a/man/atop.1
+++ b/man/atop.1
@@ -1573,6 +1573,16 @@ is loaded.
 Aggregated block I/O delay, i.e. time waiting for disk I/O.
 .PP
 .TP 9
+.B NVCSW
+Number of times that the program was context-switched voluntarily, for
+instance while waiting for an I/O operation to complete.
+.PP
+.TP 9
+.B NIVCSW
+Number of times the process was context-switched involuntarily,
+e.g. the time slice expired.
+.PP
+.TP 9
 .B CGROUP
 Path name of the cgroup (version 2) to which this process belongs.
 This path name is relative to the cgroup root directory, which

--- a/parseable.c
+++ b/parseable.c
@@ -783,7 +783,7 @@ print_PRC(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 	for (i=0; i < nact; i++, ps++)
 	{
 		printf("%s %d %s %c %u %lld %lld %d %d %d %d %d %d %d %c "
-		       "%llu %s %llu %d %d\n",
+		       "%llu %s %llu %llu %llu %d %d\n",
 			hp,
 			ps->gen.pid,
 			spaceformat(ps->gen.name, namout),
@@ -802,6 +802,8 @@ print_PRC(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 			ps->cpu.rundelay,
 			spaceformat(ps->cpu.wchan, wchanout),
 			ps->cpu.blkdelay,
+			ps->cpu.nvcsw,
+			ps->cpu.nivcsw,
 			cgroupv2max(ps->gen.isproc, ps->cpu.cgcpumax),
 			cgroupv2max(ps->gen.isproc, ps->cpu.cgcpumaxr));
 	}

--- a/photoproc.c
+++ b/photoproc.c
@@ -635,8 +635,15 @@ procstatus(struct tstat *curtask)
 			continue;
 		}
 
-		if (memcmp(line, "SigQ:", 5)==0)
-			break;
+		if (memcmp(line, "voluntary_ctxt_switches:", 24)==0) {
+			sscanf(line, "voluntary_ctxt_switches: %lld", &(curtask->cpu.nvcsw));
+			continue;
+		}
+
+		if (memcmp(line, "nonvoluntary_ctxt_switches:", 27)==0) {
+			sscanf(line, "nonvoluntary_ctxt_switches: %lld", &(curtask->cpu.nivcsw));
+			continue;
+		}
 	}
 
 	fclose(fp);

--- a/photoproc.h
+++ b/photoproc.h
@@ -83,7 +83,9 @@ struct tstat {
 		char	wchan[16];	/* wait channel string    	*/
 		count_t	rundelay;	/* schedstat rundelay (nanosec)	*/
 		count_t	blkdelay;	/* blkio delay (ticks)		*/
-		count_t	cfuture[3];	/* reserved for future use	*/
+		count_t nvcsw;		/* voluntary cxt switch counts  */
+		count_t nivcsw;		/* involuntary csw counts       */
+		count_t	cfuture[1];	/* reserved for future use	*/
 	} cpu;
 
 	/* DISK STATISTICS						*/

--- a/showgeneric.c
+++ b/showgeneric.c
@@ -2369,6 +2369,8 @@ accumulate(struct tstat *curproc, struct tstat *curstat)
 	curstat->gen.nthr   += curproc->gen.nthr;
 	curstat->cpu.utime  += curproc->cpu.utime;
 	curstat->cpu.stime  += curproc->cpu.stime;
+	curstat->cpu.nvcsw  += curproc->cpu.nvcsw;
+	curstat->cpu.nivcsw += curproc->cpu.nivcsw;
 
 	if (curproc->dsk.wsz > curproc->dsk.cwsz)
                	nett_wsz = curproc->dsk.wsz -curproc->dsk.cwsz;

--- a/showlinux.c
+++ b/showlinux.c
@@ -392,6 +392,8 @@ proc_printdef *allprocpdefs[]=
 	&procprt_RUNDELAY,
 	&procprt_BLKDELAY,
 	&procprt_WCHAN,
+	&procprt_NVCSW,
+	&procprt_NIVCSW,
 	&procprt_VGROW,
 	&procprt_RGROW,
 	&procprt_MINFLT,
@@ -1270,7 +1272,8 @@ priphead(int curlist, int totlist, char *showtype, char *showorder,
                 make_proc_prints(schedprocs, MAXITEMS, 
                         "PID:10 TID:6 CID:4 VPID:3 CTID:3 TRUN:7 TSLPI:7 "
 			"TSLPU:7 POLI:8 NICE:9 PRI:5 RTPR:9 CPUNR:8 ST:8 "
-			"EXC:8 S:8 RDELAY:8 BDELAY:7 WCHAN:5 SORTITEM:10 CMD:10",
+			"EXC:8 S:8 RDELAY:8 BDELAY:7 WCHAN:5 "
+			"NVCSW:8 NIVCSW:8 SORTITEM:10 CMD:10",
                         "built-in schedprocs");
 
                 make_proc_prints(dskprocs, MAXITEMS, 

--- a/showlinux.h
+++ b/showlinux.h
@@ -455,6 +455,8 @@ extern proc_printdef procprt_SORTITEM;
 extern proc_printdef procprt_RUNDELAY;
 extern proc_printdef procprt_BLKDELAY;
 extern proc_printdef procprt_WCHAN;
+extern proc_printdef procprt_NVCSW;
+extern proc_printdef procprt_NIVCSW;
 extern proc_printdef procprt_CGROUP_PATH;
 extern proc_printdef procprt_CGRCPUWGT;
 extern proc_printdef procprt_CGRCPUMAX;

--- a/showprocs.c
+++ b/showprocs.c
@@ -163,6 +163,10 @@ char *procprt_RUNDELAY_a(struct tstat *, int, int);
 char *procprt_RUNDELAY_e(struct tstat *, int, int);
 char *procprt_BLKDELAY_a(struct tstat *, int, int);
 char *procprt_BLKDELAY_e(struct tstat *, int, int);
+char *procprt_NVCSW_a(struct tstat *, int, int);
+char *procprt_NVCSW_e(struct tstat *, int, int);
+char *procprt_NIVCSW_a(struct tstat *, int, int);
+char *procprt_NIVCSW_e(struct tstat *, int, int);
 char *procprt_CGROUP_PATH_a(struct tstat *, int, int);
 char *procprt_CGROUP_PATH_e(struct tstat *, int, int);
 char *procprt_CGRCPUWGT_a(struct tstat *, int, int);
@@ -2186,6 +2190,42 @@ procprt_BLKDELAY_e(struct tstat *curstat, int avgval, int nsecs)
 
 proc_printdef procprt_BLKDELAY =
    { "BDELAY", "BDELAY", procprt_BLKDELAY_a, procprt_BLKDELAY_e, 6};
+/***************************************************************/
+char *
+procprt_NVCSW_a(struct tstat *curstat, int avgval, int nsecs)
+{
+	static char buf[64];
+
+	sprintf(buf, "%*lld", procprt_NVCSW.width, curstat->cpu.nvcsw);
+	return buf;
+}
+
+char *
+procprt_NVCSW_e(struct tstat *curstat, int avgval, int nsecs)
+{
+	return "    -";
+}
+
+proc_printdef procprt_NVCSW =
+   { " NVCSW", "NVCSW", procprt_NVCSW_a, procprt_NVCSW_e, 6 };
+/***************************************************************/
+char *
+procprt_NIVCSW_a(struct tstat *curstat, int avgval, int nsecs)
+{
+	static char buf[64];
+
+	sprintf(buf, "%*lld", procprt_NIVCSW.width, curstat->cpu.nivcsw);
+	return buf;
+}
+
+char *
+procprt_NIVCSW_e(struct tstat *curstat, int avgval, int nsecs)
+{
+	return "     -";
+}
+
+proc_printdef procprt_NIVCSW =
+   { "NIVCSW", "NIVCSW", procprt_NIVCSW_a, procprt_NIVCSW_e, 6 };
 /***************************************************************/
 char *
 procprt_CGROUP_PATH_a(struct tstat *curstat, int avgval, int nsecs)


### PR DESCRIPTION
As we all know, too much context switches can lead to poor performance. Besides, sometimes one same process deployed in two places may behave different. Thus it's necessary to collect the
- nvcsw (number of times that the program was context-switched voluntarily, for instance while waiting for an I/O operation to complete) and
- nivcsw (number of times the process was context-switched involuntarily, e.g. the time slice expired) two indicators to monitor the performance.

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>