### PR TITLE
Storing regex matching environment variables in the existing cmdine variable

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -298,7 +298,7 @@
 #include "json.h"
 #include "gpucom.h"
 
-#define	allflags  "ab:cde:fghijklmnopqrstuvwxyz1ABCDEFGHIJ:KL:MNOP:QRSTUVWXYZ"
+#define	allflags  "ab:cde:fghijklmnopqrstuvwxyz:1ABCDEFGHIJ:KL:MNOP:QRSTUVWXYZ"
 #define	MAXFL		64      /* maximum number of command-line flags  */
 
 /*
@@ -324,6 +324,9 @@ char      	calcpss    = 0;  /* boolean: read/calculate process PSS  */
 char      	getwchan   = 0;  /* boolean: obtain wchan string         */
 char      	rmspaces   = 0;  /* boolean: remove spaces from command  */
 		                 /* name in case of parseable output     */
+char		prependenv = 0;  /* boolean: prepend selected            */
+				 /* environment variables to cmdline     */
+regex_t		envregex;
 
 unsigned short	hertz;
 unsigned int	pidwidth;
@@ -617,6 +620,14 @@ main(int argc, char *argv[])
 
                            case MRMSPACES:	/* remove spaces from command */
 				rmspaces = 1;
+				break;
+
+			   case 'z':            /* prepend regex matching environment variables */
+				if (regcomp(&envregex, optarg, REG_NOSUB|REG_EXTENDED)) {
+					printf("Invalid environment regular expression!");
+					prusage(argv[0]);
+				}
+				prependenv = 1;
 				break;
 
 			   default:		/* gather other flags */
@@ -1102,6 +1113,8 @@ prusage(char *myname)
 			MRMSPACES);
 	printf("\t  -L  alternate line length (default 80) in case of "
 			"non-screen output\n");
+	printf("\t  -z  prepend regex matching environment variables to "
+                        "processes command line\n");
 
 	if (vis.show_usage)
 		(*vis.show_usage)();

--- a/man/atop.1
+++ b/man/atop.1
@@ -1599,7 +1599,10 @@ the total number of pages of the process/thread list are shown.
 .B COMMAND-LINE
 The full command line of the process (including arguments). If the length of
 the command line exceeds the length of the screen line, the arrow 
-keys -> and <- can be used for horizontal scroll.
+keys -> and <- can be used for horizontal scroll. The '-z <regex>' command
+line option can be used to prepend matching environment variables to the
+displayed command line. POSIX Extended Regular Expression syntax are used
+(see regex(3)).
 .br
 Behind the verb `COMMAND-LINE' in the header line, the current page number
 and the total number of pages of the process/thread list are shown.


### PR DESCRIPTION
The goal is to store selected environment variables per process.

The `-z regex` option can be used to capture some environment variables and showing them by prepending them to the displayed command line. They are stored directly in the existing `curtask->gen.cmdline` variable which is convenient for the already existing filtering mechanism. It consumes space that will not be available for the real command line though (related to https://github.com/Atoptool/atop/issues/101). 

For example, when using the SLURM HPC job scheduler, each job inherits SLURM_* variables like the jobid. It is very useful to have the job id directly accessible in atop, avoiding a manual and tedious search within the scheduler job history. With this patch, using the following atop command line and submitting an interactive SLURM job shell:

`atop -z 'SLURM_JOBID|SLURM_STEP_NUM_TASKS'`

The full command line display will be, after a 'SLURM' filter:
```
    PID     TID S   CPU COMMAND-LINE (horizontal scroll with <- and -> keys)                                                                            1/1
3686269       - R    0% SLURM_JOBID=51443556 SLURM_STEP_NUM_TASKS=1 ./atop -z SLURM_JOBID|SLURM_STEP_NUM_TASKS
3674287       - S    0% SLURM_JOBID=51443556 SLURM_STEP_NUM_TASKS=1 /bin/bash
```
