### PR TITLE
photosyst: add ceph rbd disk display

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -2085,6 +2085,8 @@ static struct {
 	{ "^dasd[a-z][a-z]*$",			{0},  nullmodname, DSKTYPE, },
 	{ "^mmcblk[0-9][0-9]*$",		{0},  nullmodname, DSKTYPE, },
 	{ "^emcpower[a-z][a-z]*$",		{0},  nullmodname, DSKTYPE, },
+	{ "^rbd[0-9][0-9]*$",			{0},  nullmodname, DSKTYPE, },
+	{ "^rbd[0-9][0-9]*p[0-9][0-9]*$",	{0},  nullmodname, DSKTYPE, },
 };
 
 static int


### PR DESCRIPTION
Ceph block devices are used in many scenarios, especially in k8s cluster, in which case an external ceph storage cluster is used to implement persistent storage for pods inside the k8s cluster.

An example in /proc/diskstats is as follows:
254 288 rbd18   25359 1 2459552 18239 2 0 16 42 0 19706 11358 0 0 0 0
254 289 rbd18p1 25240 1 2453022 18190 2 0 16 42 0 19655 11337 0 0 0 0

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>