### PR TITLE
Reinstate dropped printing of avio msec values between 99.95 and 9995

### DIFF
--- a/showsys.c
+++ b/showsys.c
@@ -2443,6 +2443,7 @@ sysprt_DSKAVIO(struct sstat *sstat, extraparam *as, int badness, int *color)
 	}
 	else if (avioms >= 99.95)
 	{
+		sprintf(buf+5, "%4.0lf ms", avioms);
 	}
 	else if (avioms >= 9.995)
 	{


### PR DESCRIPTION
I believe this was an accidental change in commit db9eef1d4 which has introduced a code path where no value is added to the buffer at all.