### PR TITLE
atop-rotate.service: use restart instead of try-restart

### DIFF
--- a/atop-rotate.service
+++ b/atop-rotate.service
@@ -4,4 +4,4 @@ Documentation=man:atop(1)
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/systemctl try-restart atop.service
+ExecStart=/usr/bin/systemctl restart atop.service


### PR DESCRIPTION
`man systemctl` says the 'try-restart' pattern:
'Restart one or more units specified on the command line if the units are running. This does nothing if units are not running.'

That means atop can not be started successfully by daily atop-rotate.timer if it is already exited. Fix this by changing try-restart to restart.

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>