### PR TITLE
calibrate the calculation of exited process info

### DIFF
--- a/acctproc.c
+++ b/acctproc.c
@@ -810,6 +810,7 @@ acctphotoproc(struct tstat *accproc, int nrprocs)
 	struct acct 		acctrec;
 	struct acct_v3 		acctrec_v3;
 	struct stat		statacc;
+	int			filled;
 
 	/*
 	** if accounting not supported, skip call
@@ -826,8 +827,7 @@ acctphotoproc(struct tstat *accproc, int nrprocs)
 	/*
 	** check all exited processes in accounting file
 	*/
-	for  (nrexit=0, api=accproc; nrexit < nrprocs;
-				nrexit++, api++, acctsize += acctrecsz)
+	for  (nrexit=0, api=accproc; nrexit < nrprocs; )
 	{
 		/*
 		** in case of shadow accounting files, we might have to
@@ -909,6 +909,7 @@ acctphotoproc(struct tstat *accproc, int nrprocs)
 
 			strncpy(api->gen.name, acctrec.ac_comm, PNAMLEN);
 			api->gen.name[PNAMLEN] = '\0';
+			filled = 1;
 			break;
 
 		   case 3:
@@ -937,7 +938,16 @@ acctphotoproc(struct tstat *accproc, int nrprocs)
 
 			strncpy(api->gen.name, acctrec_v3.ac_comm, PNAMLEN);
 			api->gen.name[PNAMLEN] = '\0';
+			filled = 1;
 			break;
+		}
+
+		if (filled == 1) {
+			nrexit++;
+			api++;
+			acctsize += acctrecsz;
+
+			filled = 0;
 		}
 	}
 


### PR DESCRIPTION
When calculating the acctsize (the previous size of account file) via acctprocnt(), sometimes atop gets a wrong number of exited processes, which makes the 'nrprocs' input parameter for acctphotoproc() become a dummy huge value, like MAXACCTPROCS.

In this case, after acctphotoproc(), we get a wrong acctsize and then lseek() a wrong position via acctrepos().

To fix this, add a flag to prove the successful filling process info from accounting-record. Only the flag is true, do we make the calculation, which includes increasing nprocexit, accumulating the acctsize, and moving the struct tstat structure pointer forward.

Signed-off-by: Fei Li <lifei.shirley@bytedance.com>