### PR TITLE
Show InCsumErrors for TCP

### DIFF
--- a/man/atop.1
+++ b/man/atop.1
@@ -1454,8 +1454,9 @@ the number of passive TCP opens (`tcppo'),
 the number of TCP output retransmissions (`tcprs'),
 the number of TCP input errors (`tcpie'),
 the number of TCP output resets (`tcpor'),
-the number of UDP no ports (`udpnp'), and
-the number of UDP input errors (`udpie').
+the number of UDP no ports (`udpnp'),
+the number of UDP input errors (`udpie'), and
+the number of TCP incorrect checksums (`csumie').
 .br
 If the screen-width does not allow all of these counters,
 only a relevant subset is shown.

--- a/netstats.h
+++ b/netstats.h
@@ -103,6 +103,7 @@ struct tcp_stats {
 	count_t RetransSegs;
 	count_t InErrs;
 	count_t OutRsts;
+	count_t InCsumErrors;
 };
 
 struct ipv6_stats {

--- a/parseable.c
+++ b/parseable.c
@@ -600,7 +600,7 @@ print_NET(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 {
 	register int 	i;
 
-	printf(	"%s %s %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
+	printf(	"%s %s %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld %lld\n",
 			hp,
 			"upper",
         		ss->net.tcp.InSegs,
@@ -626,7 +626,8 @@ print_NET(char *hp, struct sstat *ss, struct tstat *ps, int nact)
 			ss->net.tcp.CurrEstab,
 			ss->net.tcp.RetransSegs,
 			ss->net.tcp.InErrs,
-			ss->net.tcp.OutRsts);
+			ss->net.tcp.OutRsts,
+			ss->net.tcp.InCsumErrors);
 
 	for (i=0; ss->intf.intf[i].name[0]; i++)
 	{

--- a/showlinux.c
+++ b/showlinux.c
@@ -334,6 +334,7 @@ sys_printdef *nettranssyspdefs[] = {
 	&syspdef_NETTCPRETRANS,
 	&syspdef_NETTCPINERR,
 	&syspdef_NETTCPORESET,
+	&syspdef_NETTCPCSUMERR,
 	&syspdef_NETUDPNOPORT,
 	&syspdef_NETUDPINERR,
 	&syspdef_BLANKBOX,
@@ -1170,6 +1171,7 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
                         "NETTCPRETRANS:4 "
                         "NETTCPINERR:3 "
                         "NETTCPORESET:2 "
+                        "NETTCPCSUMERR:2 "
                         "NETUDPNOPORT:1 "
                         "NETUDPINERR:3",
 			nettranssyspdefs, "builtin nettransportline",

--- a/showlinux.h
+++ b/showlinux.h
@@ -312,6 +312,7 @@ extern sys_printdef syspdef_NETTCPPASVOPEN;
 extern sys_printdef syspdef_NETTCPRETRANS;
 extern sys_printdef syspdef_NETTCPINERR;
 extern sys_printdef syspdef_NETTCPORESET;
+extern sys_printdef syspdef_NETTCPCSUMERR;
 extern sys_printdef syspdef_NETUDPNOPORT;
 extern sys_printdef syspdef_NETUDPINERR;
 extern sys_printdef syspdef_NETUDPI;

--- a/showsys.c
+++ b/showsys.c
@@ -2567,6 +2567,16 @@ sysprt_NETTCPORESET(struct sstat *sstat, extraparam *as, int badness, int *color
 sys_printdef syspdef_NETTCPORESET = {"NETTCPORESET", sysprt_NETTCPORESET, NULL};
 /*******************************************************************/
 static char *
+sysprt_NETTCPCSUMERR(struct sstat *sstat, extraparam *as, int badness, int *color)
+{
+        static char buf[16]="csumie  ";
+        val2valstr(sstat->net.tcp.InCsumErrors,  buf+7, 5, as->avgval, as->nsecs);
+        return buf;
+}
+
+sys_printdef syspdef_NETTCPCSUMERR = {"NETTCPCSUMERR", sysprt_NETTCPCSUMERR, NULL};
+/*******************************************************************/
+static char *
 sysprt_NETUDPNOPORT(struct sstat *sstat, extraparam *as, int badness, int *color) 
 {
         static char buf[16]="udpnp  ";


### PR DESCRIPTION
Sometimes the packet loss is due to a checksum error, esp, in virtual machine scenarios who usually offload the checking to its host.