### PR TITLE
only call str.decode if nvml returned bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ atopcat:	atopcat.o
 		$(CC) atopcat.o -o atopcat $(LDFLAGS)
 
 clean:
-		rm -f *.o atop atopsar atopacctd atopconvert atopcat
+		rm -f *.o atop atopsar atopacctd atopconvert atopcat versdate.h
 
 distr:
 		rm -f *.o atop

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ atopcat:	atopcat.o
 		$(CC) atopcat.o -o atopcat $(LDFLAGS)
 
 clean:
-		rm -f *.o atop atopsar atopacctd atopconvert atopcat versdate.h
+		rm -f *.o atop atopsar atopacctd atopconvert atopcat
 
 distr:
 		rm -f *.o atop

--- a/atopgpud
+++ b/atopgpud
@@ -86,9 +86,17 @@ class GpuProp(object):
         self.gpuhandle         = gpuhandle
         self.stats             = Stats()
 
-        self.stats.busid       = pciInfo.busId.decode('ascii', errors='replace')
-        self.stats.devname     = pynvml.nvmlDeviceGetName(gpuhandle).decode(
-                                   'ascii', errors='replace').replace(' ', '_')
+        
+        self.stats.busid       = pciInfo.busId
+        self.stats.devname     = pynvml.nvmlDeviceGetName(gpuhandle)
+
+        # nvml backward compatibility
+        if type(self.stats.busid) == bytes:
+            self.stats.busid = self.stats.busid.decode('ascii', errors='replace') 
+        if type(self.stats.devname) == bytes:
+            self.stats.devname = self.stats.devname.decode('ascii', errors='replace') 
+
+        self.stats.devname = self.stats.devname.replace(' ', '_')
 
         self.stats.tasksupport = 0		# process stats support
 


### PR DESCRIPTION
A backward compatible fix to nvml returning a string instead of bytes that needs decoding.