### PR TITLE
fix calculation for scan and steal

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -598,13 +598,37 @@ photosyst(struct sstat *si)
 				continue;
 			}
 
-			if ( strncmp("pgscan_", nam, 7) == EQ)
+			if ( strncmp("pgscan_kswapd", nam, 13) == EQ)
 			{
 				si->mem.pgscans += cnts[0];
 				continue;
 			}
 
-			if ( strncmp("pgsteal_", nam, 8) == EQ)
+			if ( strncmp("pgscan_direct", nam, 13) == EQ)
+			{
+				si->mem.pgscans += cnts[0];
+				continue;
+			}
+
+			if ( strncmp("pgscan_khugepaged", nam, 17) == EQ)
+			{
+				si->mem.pgscans += cnts[0];
+				continue;
+			}
+
+			if ( strncmp("pgsteal_kswapd", nam, 14) == EQ)
+			{
+				si->mem.pgsteal += cnts[0];
+				continue;
+			}
+
+			if ( strncmp("pgsteal_direct", nam, 14) == EQ)
+			{
+				si->mem.pgsteal += cnts[0];
+				continue;
+			}
+
+			if ( strncmp("pgsteal_khugepaged", nam, 18) == EQ)
 			{
 				si->mem.pgsteal += cnts[0];
 				continue;


### PR DESCRIPTION
Higher kernel add new counter like pgscan_anon pgscan_file and pgscan_khugepaged in `/proc/vmstat`
pgscan_kswapd  + pgscan_direct + pgscan_khugepaged  == pgscan_anon  + pgscan_file 
But all fields which start with "pgscan_"  is counted in current implement and make it wrong with double value

```
pgscan_kswapd 130272
pgscan_direct 900
pgscan_khugepaged 0
pgscan_anon 0
pgscan_file 131172
```

Fix it by only count with pgscan_kswapd, pgscan_direct, pgscan_khugepaged,  handle pgsteal with the same method
It work well with all exist kernel.