### PR TITLE
Resolve compiler warnings from latest versions of GCC

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -1065,7 +1065,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 		/*
 		** determine new j
 		*/
-		if (pre->dsk.dsk[j].name)	// existing matching entry
+		if (pre->dsk.dsk[j].name[0])	// existing matching entry
 			j++;
 		else
 			j = realj;		// empty entry: stick to old j
@@ -1134,7 +1134,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 		/*
 		** determine new j
 		*/
-		if (pre->dsk.mdd[j].name)	// existing matching entry
+		if (pre->dsk.mdd[j].name[0])	// existing matching entry
 			j++;
 		else
 			j = realj;		// empty entry: stick to old j
@@ -1203,7 +1203,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 		/*
 		** determine new j
 		*/
-		if (pre->dsk.lvm[j].name)	// existing matching entry
+		if (pre->dsk.lvm[j].name[0])	// existing matching entry
 			j++;
 		else
 			j = realj;		// empty entry: stick to old j


### PR DESCRIPTION
Fix an incorrect struct array null test on bdev names, i.e.

"warning: the comparison will always evaluate as ‘true’ for the address of ‘name’ will never be NULL [-Waddress]"

in disk, LVM and MD block device deviate.c calculations.