### PR TITLE
Fix atop.service & atop.daily: always create $LOGPATH

### DIFF
--- a/atop.daily
+++ b/atop.daily
@@ -5,6 +5,8 @@ LOGINTERVAL=600				# default interval in seconds
 LOGGENERATIONS=28			# default number of days
 LOGPATH=/var/log/atop                   # default log location
 
+mkdir -p "$LOGPATH"
+
 # allow administrator to overrule the variables
 # defined above
 #

--- a/atop.service
+++ b/atop.service
@@ -9,6 +9,7 @@ Environment="LOGINTERVAL=600"
 Environment="LOGGENERATIONS=28"
 Environment="LOGPATH=/var/log/atop"
 EnvironmentFile=/etc/default/atop
+ExecStartPre=/bin/sh -c 'test -d "${LOGPATH}" || mkdir -p "${LOGPATH}"'
 ExecStartPre=/bin/sh -c 'test -n "$LOGINTERVAL" -a "$LOGINTERVAL" -eq "$LOGINTERVAL"'
 ExecStartPre=/bin/sh -c 'test -n "$LOGGENERATIONS" -a "$LOGGENERATIONS" -eq "$LOGGENERATIONS"'
 ExecStart=/bin/sh -c 'exec /usr/bin/atop ${LOGOPTS} -w "${LOGPATH}/atop_$(date +%%Y%%m%%d)" ${LOGINTERVAL}'


### PR DESCRIPTION
In case users remove $LOGAPTH, create it whenever atop restarts. Or else, 'no such file or directory' error will occur.