### PR TITLE
fix atopacctd.c: failed to start atopacct.service

### DIFF
--- a/atopacctd.c
+++ b/atopacctd.c
@@ -272,20 +272,12 @@ main(int argc, char *argv[])
 	}
 
 	/*
- 	** prepare cleanup signal handler
-	*/
-	memset(&sigcleanup, 0, sizeof sigcleanup);
-	sigcleanup.sa_handler	= cleanup;
-	sigemptyset(&sigcleanup.sa_mask);
-
-	/*
 	** daemonize this process
 	** i.e. be sure that the daemon is no session leader (any more)
 	** and get rid of a possible bad context that might have been
 	** inherited from ancestors
 	*/
 	parentpid = getpid();		// to be killed when initialized
-	(void) sigaction(SIGTERM, &sigcleanup, (struct sigaction *)0);
 
 	if ( fork() )			// implicitly switch to background
    	{
@@ -303,6 +295,15 @@ main(int argc, char *argv[])
 
 	if ( fork() )			// finish parent; continue in child
 		exit(0);		// --> no session leader, no ctty
+	
+	/*
+ 	** prepare cleanup signal handler
+	*/
+	memset(&sigcleanup, 0, sizeof sigcleanup);
+	sigcleanup.sa_handler	= cleanup;
+	sigemptyset(&sigcleanup.sa_mask);
+	(void) sigaction(SIGTERM, &sigcleanup, (struct sigaction *)0);
+
 
 	getrlimit(RLIMIT_NOFILE, &rlim);
 


### PR DESCRIPTION
The type of atopacct.service is "forking". If the parent process does not exit within 90 seconds after starting, the service is considered to have failed to start.
After executing fork(), there is a situation where the child process gets scheduled before the parent process. When the child process reaches the kill() function and sends a signal to the parent process, the parent process has not yet been scheduled. After receiving the signal, the parent process executes the signal handling function but has not yet reached the pause() function. As a result, the parent process gets stuck in the pause() function and does not exit, causing the atopacct.service to fail to start.