### PR TITLE
Correct tslpu by calculating only 'D' but not 'I'

### DIFF
--- a/photoproc.c
+++ b/photoproc.c
@@ -334,7 +334,6 @@ photoproc(struct tstat *tasklist, int maxtask)
 	   		   		   case 'S':
 						curtask->gen.nthrslpi += 1;
 						break;
-	   		   		   case 'I':
 	   		   		   case 'D':
 						curtask->gen.nthrslpu += 1;
 						break;
@@ -533,7 +532,6 @@ procstat(struct tstat *curtask, unsigned long long bootepoch, char isproc)
   	   case 'S':
 		curtask->gen.nthrslpi = 1;
 		break;
-	   case 'I':
   	   case 'D':
 		curtask->gen.nthrslpu = 1;
 		break;


### PR DESCRIPTION
According to task_state_array[] from Linux kernel, "D (disk sleep)" is reported for TASK_UNINTERRUPTIBLE, and "I (idle)" is reported for TASK_IDLE[1], which composes by (TASK_UNINTERRUPTIBLE | TASK_NOLOAD). The special flag TASK_NOLOAD[2] is added for calculating idle kernel threads which do not contribute to load average like uninterruptible processes do.

Thus only TASK_UNINTERRUPTIBLE("D") is needed. Rectify this by reverting the previous patch:
"Count idle threads as non-interruptible threads" as https://github.com/Atoptool/atop/commit/bb38fd80633cf11475fc18191d4cc8bf3f0e67ba

[1]https://yhbt.net/lore/all/20170925121117.224552932@infradead.org/1-peterz-sched-state-6.patch
[2]https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=80ed87c8a9ca0cad7ca66cf3bbdfb17559a66dcf