### PR TITLE
supplement AnonHugepages memory consumption

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -717,6 +717,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 	dev->mem.shmrss		= cur->mem.shmrss;
 	dev->mem.shmswp		= cur->mem.shmswp;
 
+	dev->mem.anonhugepage	= cur->mem.anonhugepage;
 	dev->mem.tothugepage	= cur->mem.tothugepage;
 	dev->mem.freehugepage	= cur->mem.freehugepage;
 	dev->mem.hugepagesz	= cur->mem.hugepagesz;

--- a/man/atop.1
+++ b/man/atop.1
@@ -1436,6 +1436,7 @@ the amount of memory that is currently claimed by vmware's
 balloon driver ('vmbal'),
 the amount of memory that is currently claimed by the ARC (cache)
 of ZFSonlinux ('zfarc'),
+the number of anonymous transparent huge page ('anonhp'),
 the amount of memory that is claimed for huge pages ('hptot'),
 the amount of huge page memory that is really in use ('hpuse'),
 the amount of memory that is used for TCP sockets ('tcps'), and

--- a/photosyst.c
+++ b/photosyst.c
@@ -797,6 +797,10 @@ photosyst(struct sstat *si)
 					si->mem.commitlim = cnts[0]*1024/
 								pagesize;
 				}
+			else	if (strcmp("AnonHugePages:", nam) == EQ)
+				{
+					si->mem.anonhugepage = cnts[0]*1024;
+				}
 			else	if (strcmp("HugePages_Total:", nam) == EQ)
 				{
 					si->mem.tothugepage = cnts[0];

--- a/photosyst.h
+++ b/photosyst.h
@@ -71,7 +71,7 @@ struct	memstat {
 	count_t	shmswp;		// swapped shared memory (pages)
 
 	count_t	slabreclaim;	// reclaimable slab (pages)
-
+	count_t anonhugepage;   // anonymous transparent huge pages (bytes)
 	count_t	tothugepage;	// total huge pages (huge pages)
 	count_t	freehugepage;	// free  huge pages (huge pages)
 	count_t	hugepagesz;	// huge page size (bytes)
@@ -90,7 +90,7 @@ struct	memstat {
 	count_t	pgouts;		// total number of pages written to block device
 	count_t	pgins;		// total number of pages read from block device
 	count_t	pagetables;	// page tables of processes (pages)
-	count_t	cfuture[4];	// reserved for future use
+	count_t	cfuture[3];	// reserved for future use
 };
 
 /************************************************************************/

--- a/showlinux.c
+++ b/showlinux.c
@@ -160,6 +160,7 @@ sys_printdef *memsyspdefs1[] = {
 	&syspdef_BLANKBOX,
 	&syspdef_PAGETABS,
 	&syspdef_BLANKBOX,
+	&syspdef_ANONHUP,
 	&syspdef_HUPTOT,
 	&syspdef_HUPUSE,
         0
@@ -935,7 +936,7 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
 	                "RECSLAB:3 "
 	                "BLANKBOX:0 "
 	                "PAGETABS:4 "
-	                "BLANKBOX:0 "
+                        "ANONHUP:5 "
 	                "HUPTOT:5 "
 	                "HUPUSE:2 ",
 			memsyspdefs1, "builtin memline1",

--- a/showlinux.h
+++ b/showlinux.h
@@ -229,6 +229,7 @@ extern sys_printdef syspdef_SHMSWP;
 extern sys_printdef syspdef_VMWBAL;
 extern sys_printdef syspdef_ZFSARC;
 extern sys_printdef syspdef_PAGETABS;
+extern sys_printdef syspdef_ANONHUP;
 extern sys_printdef syspdef_HUPTOT;
 extern sys_printdef syspdef_HUPUSE;
 extern sys_printdef syspdef_SWPTOT;

--- a/showsys.c
+++ b/showsys.c
@@ -1317,6 +1317,24 @@ sysprt_SHMSWP(struct sstat *sstat, extraparam *notused, int badness, int *color)
 sys_printdef syspdef_SHMSWP = {"SHMSWP", sysprt_SHMSWP, NULL};
 /*******************************************************************/
 static char *
+sysprt_ANONHUP(struct sstat *sstat, extraparam *notused, int badness, int *color)
+{
+        static char buf[16]="anonhp  ";
+
+	*color = -1;
+        val2memstr(sstat->mem.anonhugepage, buf+6, MBFORMAT, 0, 0);
+        return buf;
+}
+
+static int
+sysval_ANONHUP(struct sstat *sstat)
+{
+	return sstat->mem.anonhugepage;
+}
+
+sys_printdef syspdef_ANONHUP = {"ANONHUP", sysprt_ANONHUP, sysval_ANONHUP};
+/*******************************************************************/
+static char *
 sysprt_HUPTOT(struct sstat *sstat, extraparam *notused, int badness, int *color) 
 {
         static char buf[16]="hptot  ";


### PR DESCRIPTION
HugePages is a feature integrated into the Linux kernel with release 2.6. It is a method to have larger pages where it is useful for working with very large memory. But it can be difficult to manage manually, and often require significant changes to code in order to be used effectively.

**THP** hides much of the complexity in using huge pages from system administrators and developers. It will always try to allocate memory with huge pages by kernel. 

On some operating system distributions, users have enabled thp. And turning on THP may cause some unusual performance problems. Therefore it is necessary to collect.


