### PR TITLE
Fix drawbar mvwprintw format-security error

### DIFF
--- a/drawbar.c
+++ b/drawbar.c
@@ -2055,7 +2055,7 @@ drawevent(struct perwindow *w, int line, int column, int color,
 
 	line -= 1;
        	wattron(w->win, A_BOLD);
-	mvwprintw(w->win, line, column, text);
+	mvwprintw(w->win, line, column, "%s", text);
        	wattroff(w->win, A_BOLD);
 
 	colorswoff(w->win, color);
@@ -2105,7 +2105,7 @@ headergetch(time_t curtime, int nsecs, char *statusmsg, int statuscol)
 	{
         	colorswon(headwin, statuscol);
 		wattron(headwin, A_REVERSE);
-		mvwprintw(headwin, 0, statcol, statusmsg);
+		mvwprintw(headwin, 0, statcol, "%s", statusmsg);
 		wattroff(headwin, A_REVERSE);
         	colorswoff(headwin, statuscol);
 	}
@@ -2328,7 +2328,7 @@ getwininput(char *prompt, char *answer, int maxanswer, char numerical)
 
 	// show the prompt
 	//
-	mvwprintw(mywin, 1, 1, prompt);
+	mvwprintw(mywin, 1, 1, "%s", prompt);
 
 	// prepare reading input
 	//


### PR DESCRIPTION
When building with `-Werror=format-security` there are some issues with the use of mvwprintw in drawbar.c

```
export CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
        -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security \
        -fstack-clash-protection -fcf-protection"

make
...
cc -march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -fcf-protection -O2 -I. -Wall -Wno-stringop-truncation -Wmissing-prototypes -Wmissing-declarations    -c -o drawbar.o drawbar.c
drawbar.c: In function ‘drawevent’:
drawbar.c:2058:9: error: format not a string literal and no format arguments [-Werror=format-security]
 2058 |         mvwprintw(w->win, line, column, text);
      |         ^~~~~~~~~
drawbar.c: In function ‘headergetch’:
drawbar.c:2108:17: error: format not a string literal and no format arguments [-Werror=format-security]
 2108 |                 mvwprintw(headwin, 0, statcol, statusmsg);
      |                 ^~~~~~~~~
drawbar.c: In function ‘getwininput’:
drawbar.c:2331:9: error: format not a string literal and no format arguments [-Werror=format-security]
 2331 |         mvwprintw(mywin, 1, 1, prompt);
      |         ^~~~~~~~~
cc1: some warnings being treated as errors
make: *** [<builtin>: drawbar.o] Error 1
```

By explicitly adding the format `"%s"` this error is fixed.