### PR TITLE
add RDELAY/BDELAY for container

### DIFF
--- a/showgeneric.c
+++ b/showgeneric.c
@@ -2518,6 +2518,8 @@ accumulate(struct tstat *curproc, struct tstat *curstat)
 	curstat->cpu.stime  += curproc->cpu.stime;
 	curstat->cpu.nvcsw  += curproc->cpu.nvcsw;
 	curstat->cpu.nivcsw += curproc->cpu.nivcsw;
+	curstat->cpu.rundelay += curproc->cpu.rundelay;
+	curstat->cpu.blkdelay += curproc->cpu.blkdelay;
 
 	if (curproc->dsk.wsz > curproc->dsk.cwsz)
                	nett_wsz = curproc->dsk.wsz -curproc->dsk.cwsz;

--- a/showlinux.c
+++ b/showlinux.c
@@ -1329,7 +1329,7 @@ priphead(int curlist, int totlist, char *showtype, char *showorder,
                         "built-in totprocs");
 
                 make_proc_prints(totconts, MAXITEMS, 
-                        "NPROCS:10 SYSCPU:9 USRCPU:9 VSIZE:6 "
+                        "NPROCS:10 SYSCPU:9 USRCPU:9 RDELAY:8 BDELAY:7 VSIZE:6 "
                         "RSIZE:8 PSIZE:8 LOCKSZ:3 SWAPSZ:5 RDDSK:7 CWRDSK:7 "
 			"RNET:6 SNET:6 SORTITEM:10 CID:10", 
                         "built-in totconts");


### PR DESCRIPTION
Add RDEALY and BDEALY to the container, and count the value of cpu wait or iowait in the container to facilitate troubleshooting container problems.