### PR TITLE
Fix typo "upto" in atoprc.5

### DIFF
--- a/man/atoprc.5
+++ b/man/atoprc.5
@@ -172,7 +172,7 @@ performed.
 Number of columns used per bar in the processor bar graph.
 The default value is 0 which means that the bar width will
 be scaled automatically (the wider the terminal, the more
-columns per bar upto a maximum of three).
+columns per bar up to a maximum of three).
 With the value 1, 2 or 3 the number of bars can be statically
 pinned to that number of columns, with one column of white
 space in between the bars.


### PR DESCRIPTION
This fixes a typo that was detected by lintian in the course of packaging atop for Debian.