### PR TITLE
Exited process copy pre cid

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -312,6 +312,7 @@ deviattask(struct tstat    *curtpres, unsigned long ntaskpres,
 			devstat->gen.excode |= ~(INT_MAX);
 
 		strcpy(devstat->gen.cmdline, prestat.gen.cmdline);
+		strcpy(devstat->gen.container, prestat.gen.container);
 
 		devstat->cpu.curcpu = -1;
 


### PR DESCRIPTION
When the process is  an exited process, its cid is '?'. CID can get from prestat, it should be shown.