### PR TITLE
Resolve a memory leak when switching to bar graph mode (covscan)

### DIFF
--- a/showgeneric.c
+++ b/showgeneric.c
@@ -1059,6 +1059,16 @@ text_samp(time_t curtime, int nsecs,
 			   case MBARGRAPH:
 				erase();
 				refresh();
+
+				if (tpcumlist) free(tpcumlist);
+				if (pcumlist)  free(pcumlist);
+				if (tucumlist) free(tucumlist);
+				if (ucumlist)  free(ucumlist);
+				if (tccumlist) free(tccumlist);
+				if (ccumlist)  free(ccumlist);
+				if (tsklist)   free(tsklist);
+				if (sellist)   free(sellist);
+
 				return lastchar;
 
 			   /*


### PR DESCRIPTION
Tackles the following covscan issue in a MBARGRAPH switch case:
>>>     CID 394863:  Resource leaks  (RESOURCE_LEAK)
>>>     Variable "curlist" going out of scope leaks the storage it points to.