### PR TITLE
add NRCORE/NRSIGKILL for container

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -312,6 +312,7 @@ deviattask(struct tstat    *curtpres, unsigned long ntaskpres,
 			devstat->gen.excode |= ~(INT_MAX);
 
 		strcpy(devstat->gen.cmdline, prestat.gen.cmdline);
+		strcpy(devstat->gen.container, prestat.gen.container);
 
 		devstat->cpu.curcpu = -1;
 

--- a/showgeneric.c
+++ b/showgeneric.c
@@ -2586,6 +2586,14 @@ accumulate(struct tstat *curproc, struct tstat *curstat)
 					curstat->gpu.nrgpus++;
 			}
 		}
+	} else {
+		if (curproc->gen.excode & 0xff)
+		{
+			if (curproc->gen.excode & 0x80)
+				curstat->gen.nthrslpi++;	// coredump
+			else if ((curproc->gen.excode & 0x7f) == 9 )
+				curstat->gen.nthrslpu++;	// sigkill
+		}
 	}
 }
 

--- a/showlinux.c
+++ b/showlinux.c
@@ -439,6 +439,8 @@ proc_printdef *allprocpdefs[]=
 	&procprt_S,
 	&procprt_COMMAND_LINE,
 	&procprt_NPROCS,
+	&procprt_NRSIGKILL,
+	&procprt_NRCORE,
 	&procprt_RDDSK,
 	&procprt_WRDSK,
 	&procprt_CWRDSK,
@@ -1331,7 +1333,7 @@ priphead(int curlist, int totlist, char *showtype, char *showorder,
                 make_proc_prints(totconts, MAXITEMS, 
                         "NPROCS:10 SYSCPU:9 USRCPU:9 VSIZE:6 "
                         "RSIZE:8 PSIZE:8 LOCKSZ:3 SWAPSZ:5 RDDSK:7 CWRDSK:7 "
-			"RNET:6 SNET:6 SORTITEM:10 CID:10", 
+			"RNET:6 SNET:6 NRSIGKILL:8 NRCORE:8 SORTITEM:10 CID:10",
                         "built-in totconts");
         }
 

--- a/showlinux.h
+++ b/showlinux.h
@@ -470,6 +470,8 @@ extern proc_printdef procprt_CGRMEMMAX;
 extern proc_printdef procprt_CGRMEMMAXR;
 extern proc_printdef procprt_CGRSWPMAX;
 extern proc_printdef procprt_CGRSWPMAXR;
+extern proc_printdef procprt_NRSIGKILL;
+extern proc_printdef procprt_NRCORE;
 
 
 //extern char *procprt_NRDDSK_ae(struct tstat *, int, int);

--- a/showprocs.c
+++ b/showprocs.c
@@ -186,6 +186,8 @@ char *procprt_CGRSWPMAX_e(struct tstat *, int, int);
 char *procprt_CGRSWPMAXR_a(struct tstat *, int, int);
 char *procprt_CGRSWPMAXR_e(struct tstat *, int, int);
 char *procprt_SORTITEM_ae(struct tstat *, int, int);
+char *procprt_NRSIGKILL_ae(struct tstat *, int, int);
+char *procprt_NRCORE_ae(struct tstat *, int, int);
 
 
 static char     *columnhead[] = {
@@ -2528,3 +2530,27 @@ procprt_SORTITEM_ae(struct tstat *curstat, int avgval, int nsecs)
 
 proc_printdef procprt_SORTITEM =   // width is dynamically defined!
    { 0, "SORTITEM", procprt_SORTITEM_ae, procprt_SORTITEM_ae, 4};
+/***************************************************************/
+char *
+procprt_NRSIGKILL_ae(struct tstat *curstat, int avgval, int nsecs)
+{
+       static char buf[10];
+
+        val2valstr(curstat->gen.nthrslpu, buf, 6, 0, 0); // pid abused as proc counter
+        return buf;
+}
+
+proc_printdef procprt_NRSIGKILL =   // width is dynamically defined!
+   {"NRSIGKILL", "NRSIGKILL", procprt_NRSIGKILL_ae, procprt_NRSIGKILL_ae, 4};
+/***************************************************************/
+char *
+procprt_NRCORE_ae(struct tstat *curstat, int avgval, int nsecs)
+{
+       static char buf[10];
+
+        val2valstr(curstat->gen.nthrslpi, buf, 6, 0, 0); // pid abused as proc counter
+        return buf;
+}
+
+proc_printdef procprt_NRCORE =   // width is dynamically defined!
+   {"NRCORE", "NRCORE", procprt_NRCORE_ae, procprt_NRCORE_ae, 4};


### PR DESCRIPTION
Frequent oom (receiving sigkill signals) in the container may affect the whole machine. It will be helpful to monitor the number of sigkill processes in this situation.
Frequent coreump in the container, the business process in the container may have logical errors. It will be helpful to monitor the number of coredump processes in this situation.