### PR TITLE
Json formatting

### DIFF
--- a/json.c
+++ b/json.c
@@ -402,8 +402,8 @@ static void json_print_GPU(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			printf(", ");
 		}
 		printf("{\"gpuid\": %d, "
-			"\"busid\": \"%.19s\", "
-			"\"type\": \"%.19s\", "
+			"\"busid\": \"%s\", "
+			"\"type\": \"%s\", "
 			"\"gpupercnow\": %d, "
 			"\"mempercnow\": %d, "
 			"\"memtotnow\": %lld, "
@@ -554,7 +554,7 @@ static void json_print_LVM(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"lvmname\": \"%.19s\", "
+		printf("{\"lvmname\": \"%s\", "
 			"\"io_ms\": %lld, "
 			"\"nread\": %lld, "
 			"\"nrsect\": %lld, "
@@ -585,7 +585,7 @@ static void json_print_MDD(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"mddname\": \"%.19s\", "
+		printf("{\"mddname\": \"%s\", "
 			"\"io_ms\": %lld, "
 			"\"nread\": %lld, "
 			"\"nrsect\": %lld, "
@@ -616,7 +616,7 @@ static void json_print_DSK(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"dskname\": \"%.19s\", "
+		printf("{\"dskname\": \"%s\", "
 			"\"io_ms\": %lld, "
 			"\"nread\": %lld, "
 			"\"nrsect\": %lld, "
@@ -649,7 +649,7 @@ static void json_print_NFM(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"mountdev\": \"%.19s\", "
+		printf("{\"mountdev\": \"%s\", "
 			"\"bytestotread\": %lld, "
 			"\"bytestotwrite\": %lld, "
 			"\"bytesread\": %lld, "
@@ -770,7 +770,7 @@ static void json_print_NET(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"name\": \"%.19s\", "
+		printf("{\"name\": \"%s\", "
 			"\"rpack\": %lld, "
 			"\"rbyte\": %lld, "
 			"\"rerrs\": %lld, "
@@ -803,7 +803,7 @@ static void json_print_IFB(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"ibname\": \"%.19s\", "
+		printf("{\"ibname\": \"%s\", "
 			"\"portnr\": \"%hd\", "
 			"\"lanes\": \"%hd\", "
 			"\"maxrate\": %lld, "
@@ -962,7 +962,7 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 
 		/* using getpwuid() & getpwuid to convert ruid & euid to string seems better, but the two functions take a long time */
 		printf("{\"pid\": %d, "
-			"\"name\": \"(%.19s)\", "
+			"\"name\": \"%s\", "
 			"\"state\": \"%c\", "
 			"\"ruid\": %d, "
 			"\"rgid\": %d, "
@@ -971,7 +971,7 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"st\": \"%s\", "
 			"\"exitcode\": %d, "
 			"\"btime\": \"%ld\", "
-			"\"cmdline\": \"(%.130s)\", "
+			"\"cmdline\": \"%s\", "
 			"\"ppid\": %d, "
 			"\"nthrrun\": %d, "
 			"\"nthrslpi\": %d, "
@@ -981,7 +981,7 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"egid\": %d, "
 			"\"elaps\": \"%ld\", "
 			"\"isproc\": %d, "
-			"\"cid\": \"%.19s\"}",
+			"\"cid\": \"%s\"}",
 			ps->gen.pid,
 			ps->gen.name,
 			ps->gen.state,

--- a/json.c
+++ b/json.c
@@ -510,7 +510,7 @@ static void json_print_PSI(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		return;
 
 	printf(", %s: {"
-		"\"psi\": \"%c\", "
+		"\"psi\": %s, "
 		"\"cs10\": %.1f, "
 		"\"cs60\": %.1f, "
 		"\"cs300\": %.1f, "
@@ -531,7 +531,7 @@ static void json_print_PSI(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		"\"iof60\": %.1f, "
 		"\"iof300\": %.1f, "
 		"\"ioftot\": %llu}",
-		hp, ss->psi.present ? 'y' : 'n',
+		hp, ss->psi.present ? "true" : "false",
 		ss->psi.cpusome.avg10, ss->psi.cpusome.avg60,
 		ss->psi.cpusome.avg300, ss->psi.cpusome.total,
 		ss->psi.memsome.avg10, ss->psi.memsome.avg60,
@@ -778,7 +778,7 @@ static void json_print_NET(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"sbyte\": %lld, "
 			"\"serrs\": %lld, "
 			"\"speed\": %ld, "
-			"\"duplex\": %d}",
+			"\"duplex\": %s}",
 			ss->intf.intf[i].name,
 			ss->intf.intf[i].rpack,
 			ss->intf.intf[i].rbyte,
@@ -787,7 +787,7 @@ static void json_print_NET(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			ss->intf.intf[i].sbyte,
 			ss->intf.intf[i].serrs,
 			ss->intf.intf[i].speed,
-			ss->intf.intf[i].duplex);
+			ss->intf.intf[i].duplex == 1 ? "true" : "false");
 	}
 
 	printf("]");
@@ -980,7 +980,7 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"euid\": %d, "
 			"\"egid\": %d, "
 			"\"elaps\": %ld, "
-			"\"isproc\": %d, "
+			"\"isproc\": %s, "
 			"\"cid\": \"%s\"}",
 			ps->gen.pid,
 			ps->gen.name,
@@ -1001,7 +1001,7 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			ps->gen.euid,
 			ps->gen.egid,
 			ps->gen.elaps,
-			!!ps->gen.isproc, /* convert to boolean */
+			!!ps->gen.isproc == 1 ? "true" : "false",
 			ps->gen.container[0] ? ps->gen.container:"-");
 	}
 
@@ -1027,7 +1027,7 @@ static void json_print_PRC(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"prio\": %d, "
 			"\"curcpu\": %d, "
 			"\"tgid\": %d, "
-			"\"isproc\": %d, "
+			"\"isproc\": %s, "
 			"\"rundelay\": %lld, "
 			"\"blkdelay\": %lld, "
 			"\"nvcsw\": %llu, "
@@ -1040,7 +1040,7 @@ static void json_print_PRC(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			ps->cpu.prio,
 			ps->cpu.curcpu,
 			ps->gen.tgid,
-			!!ps->gen.isproc,
+			!!ps->gen.isproc == 1 ? "true" : "false",
 			ps->cpu.rundelay/1000000,
 			ps->cpu.blkdelay*1000/hertz,
 			ps->cpu.nvcsw,

--- a/json.c
+++ b/json.c
@@ -777,7 +777,7 @@ static void json_print_NET(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"spack\": %lld, "
 			"\"sbyte\": %lld, "
 			"\"serrs\": %lld, "
-			"\"speed\": \"%ld\", "
+			"\"speed\": %ld, "
 			"\"duplex\": %d}",
 			ss->intf.intf[i].name,
 			ss->intf.intf[i].rpack,
@@ -804,8 +804,8 @@ static void json_print_IFB(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			printf(", ");
 		}
 		printf("{\"ibname\": \"%s\", "
-			"\"portnr\": \"%hd\", "
-			"\"lanes\": \"%hd\", "
+			"\"portnr\": %hd, "
+			"\"lanes\": %hd, "
 			"\"maxrate\": %lld, "
 			"\"rcvb\": %lld, "
 			"\"sndb\": %lld, "
@@ -834,8 +834,8 @@ static void json_print_NUM(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"numanr\": \"%d\", "
-			"\"frag\": \"%f\", "
+		printf("{\"numanr\": %d, "
+			"\"frag\": %f, "
 			"\"totmem\": %lld, "
 			"\"freemem\": %lld, "
 			"\"active\": %lld, "
@@ -873,7 +873,7 @@ static void json_print_NUC(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"numanr\": \"%d\", "
+		printf("{\"numanr\": %d, "
 			"\"stime\": %lld, "
 			"\"utime\": %lld, "
 			"\"ntime\": %lld, "
@@ -908,9 +908,9 @@ static void json_print_LLC(char *hp, struct sstat *ss, struct tstat *ps, int nac
 		if (i > 0) {
 			printf(", ");
 		}
-		printf("{\"LLC\": \"%3d\", "
-			"\"occupancy\": \"%3.1f%%\", "
-			"\"mbm_total\": \"%lld\", "
+		printf("{\"LLC\": %3d, "
+			"\"occupancy\": %3.1f, "
+			"\"mbm_total\": %lld, "
 			"\"mbm_local\": %lld}",
 			ss->llc.perllc[i].id,
 			ss->llc.perllc[i].occupancy * 100,
@@ -970,7 +970,7 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"nthr\": %d, "
 			"\"st\": \"%s\", "
 			"\"exitcode\": %d, "
-			"\"btime\": \"%ld\", "
+			"\"btime\": %ld, "
 			"\"cmdline\": \"%s\", "
 			"\"ppid\": %d, "
 			"\"nthrrun\": %d, "
@@ -979,7 +979,7 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"nthridle\": %d, "
 			"\"euid\": %d, "
 			"\"egid\": %d, "
-			"\"elaps\": \"%ld\", "
+			"\"elaps\": %ld, "
 			"\"isproc\": %d, "
 			"\"cid\": \"%s\"}",
 			ps->gen.pid,
@@ -1139,14 +1139,14 @@ static void json_print_PRN(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			printf(", ");
 		}
 		printf("{\"pid\": %d, "
-			"\"tcpsnd\": \"%lld\", "
-			"\"tcpssz\": \"%lld\", "
-			"\"tcprcv\": \"%lld\", "
-			"\"tcprsz\": \"%lld\", "
-			"\"udpsnd\": \"%lld\", "
-			"\"udpssz\": \"%lld\", "
-			"\"udprcv\": \"%lld\", "
-			"\"udprsz\": \"%lld\"}",
+			"\"tcpsnd\": %lld, "
+			"\"tcpssz\": %lld, "
+			"\"tcprcv\": %lld, "
+			"\"tcprsz\": %lld, "
+			"\"udpsnd\": %lld, "
+			"\"udpssz\": %lld, "
+			"\"udprcv\": %lld, "
+			"\"udprsz\": %lld}",
 			ps->gen.pid,
 			ps->net.tcpsnd, ps->net.tcpssz,
 			ps->net.tcprcv, ps->net.tcprsz,


### PR DESCRIPTION
Hope to make json output more usable:

- Trimmed strings is problematic. It makes sense to keep things tidy for visual output, but doesn't seem to serve a purpose for json output. In my use case I have dozens of gluster mounts where the mount point path is too long to be able to distinguish which mount is which after the path string is trimmed.
- Unless there is some corner-case or scenario I'm unaware of, it doesn't make much sense to quote numbers/floats as strings. When consuming json output I would have to convert them all back to numbers to make any use of them. There is one instance where the value is expressed as a percentage, but in consuming the data I would still need to convert to a numeric representation.
- Utilize bool types instead of 'y'/'n' or 1/0