### PR TITLE
Use -999 as OOM adj

### DIFF
--- a/various.c
+++ b/various.c
@@ -814,7 +814,7 @@ void
 set_oom_score_adj(void)
 {
 	int fd;
-	char val[] = "-1000";	/* suggested by Gerlof, always set -1000 */
+	char val[] = "-999";	/* suggested by Gerlof, always set -999 */
 
 	/*
 	 ** set OOM score adj to avoid to lost necessary log of system.


### PR DESCRIPTION
The atop deployment usually follows the rules:
- atop MUST NOT exceed the cgroup resource limitations
- atop has a higher priority on OOM

OOM_SCORE_ADJ_MIN(-1000) is a magic number which could *not* be killed by memory cgroup, this breaks the rules.

Detail of OOM_SCORE_ADJ_MIN, see linux/mm/oom_kill.c /*
 * Kill provided task unless it's secured by setting
 * oom_score_adj to OOM_SCORE_ADJ_MIN. */ static int oom_kill_memcg_member(struct task_struct *task, void *message) {
        if (task->signal->oom_score_adj != OOM_SCORE_ADJ_MIN &&
            !is_global_init(task)) {
                get_task_struct(task);
                __oom_kill_process(task, message);
        }
        return 0;
}

Use -999 instead of -1000 as atop default OOM adj.