### PR TITLE
Return error when the accounting file can not be read

### DIFF
--- a/acctproc.c
+++ b/acctproc.c
@@ -446,6 +446,7 @@ atopacctd(int swon)
 						{
 							(void) close(acctfd);
 							acctfd = -1;
+							maxshadowrec = 0;
 
 							semop(sempacctpubid,
 								&semrelse, 1);
@@ -453,7 +454,7 @@ atopacctd(int swon)
 								&semunlock, 1);
 
 							regainrootprivs();
-							return 1;
+							return -1;
 						}
 					}
 


### PR DESCRIPTION
This addresses https://github.com/Atoptool/atop/issues/277 

Testing: 
 - ran atop in lxc container. 
 atop started with the error message `no  procacct`.


