### PR TITLE
atop.h: include time.h

### DIFF
--- a/atop.h
+++ b/atop.h
@@ -24,6 +24,8 @@
 #ifndef __ATOP__
 #define __ATOP__
 
+#include <time.h>
+
 #define	EQ		0
 #define SECONDSINDAY	86400
 #define RAWNAMESZ	256


### PR DESCRIPTION
Include `time.h` to avoid the following build failure with musl:

```
atop.h:157:1: error: unknown type name 'time_t'
  157 | time_t          normalize_epoch(time_t, long);
      | ^~~~~~
atop.h:157:1: note: 'time_t' is defined in header '<time.h>'; did you forget to '#include <time.h>'?
atop.h:157:40: error: expected ')' before 'long'
  157 | time_t          normalize_epoch(time_t, long);
      |                                        ^~~~~
      |                                        )
```

Fixes:
 - http://autobuild.buildroot.org/results/e7ec8d16f2299320f374a0198c8e9b18a102b037