### PR TITLE
Replace non-standard "ushort" type with "unsigned short"

### DIFF
--- a/acctproc.c
+++ b/acctproc.c
@@ -122,8 +122,8 @@ int
 acctswon(void)
 {
 	int			i, j, sematopid;
-	static ushort 		vals[] = {1, ATOPACCTTOT};
-	union {ushort *array;}	arg = {vals};
+	static unsigned short 		vals[] = {1, ATOPACCTTOT};
+	union {unsigned short *array;}	arg = {vals};
 	struct stat		statbuf;
 	char			*ep;
 	int			ret;


### PR DESCRIPTION
"ushort" is a typedef provided for System V compatibility in "sys/types.h" by *most* Linux toolchains. Android sys/types.h does not have it.

All other parts of Atop use the standard "unsigned short" type.

There are no downsides to the change and the upside is better compatibility by following the standard.