### PR TITLE
json: Print cgroups'a name when using -J and the label

### DIFF
--- a/json.c
+++ b/json.c
@@ -989,7 +989,8 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"egid\": %d, "
 			"\"elaps\": \"%ld\", "
 			"\"isproc\": %d, "
-			"\"cid\": \"%.19s\"}",
+			"\"cid\": \"%.19s\", "
+			"\"cgroup\": \"%s\"}",
 			ps->gen.pid,
 			ps->gen.name,
 			ps->gen.state,
@@ -1010,7 +1011,8 @@ static void json_print_PRG(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			ps->gen.egid,
 			ps->gen.elaps,
 			!!ps->gen.isproc, /* convert to boolean */
-			ps->gen.utsname[0] ? ps->gen.utsname:"-");
+			ps->gen.utsname[0] ? ps->gen.utsname:"-",
+			ps->gen.cgpath[0] ? ps->gen.cgpath:"-");
 	}
 
 	printf("]");

--- a/json.c
+++ b/json.c
@@ -1042,7 +1042,8 @@ static void json_print_PRC(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"blkdelay\": %lld, "
 			"\"nvcsw\": %llu, "
 			"\"nivcsw\": %llu, "
-			"\"sleepavg\": %d}",
+			"\"sleepavg\": %d, "
+			"\"cgroup\": \"%s\"}",
 			ps->gen.pid,
 			ps->cpu.utime,
 			ps->cpu.stime,
@@ -1055,7 +1056,8 @@ static void json_print_PRC(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			ps->cpu.blkdelay*1000/hertz,
 			ps->cpu.nvcsw,
 			ps->cpu.nivcsw,
-			ps->cpu.sleepavg);
+			ps->cpu.sleepavg,
+			ps->gen.cgpath[0] ? ps->gen.cgpath:"-");
 	}
 
 	printf("]");
@@ -1086,7 +1088,8 @@ static void json_print_PRM(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			"\"vstack\": %lld, "
 			"\"vlock\": %lld, "
 			"\"vswap\": %lld, "
-			"\"pmem\": %lld}",
+			"\"pmem\": %lld, "
+			"\"cgroup\": \"%s\"}",
 			ps->gen.pid,
 			ps->mem.vmem,
 			ps->mem.rmem,
@@ -1101,7 +1104,8 @@ static void json_print_PRM(char *hp, struct sstat *ss, struct tstat *ps, int nac
 			ps->mem.vlock,
 			ps->mem.vswap,
 			ps->mem.pmem == (unsigned long long)-1LL ?
-			0:ps->mem.pmem);
+			0:ps->mem.pmem,
+			ps->gen.cgpath[0] ? ps->gen.cgpath:"-");
 	}
 
 	printf("]");


### PR DESCRIPTION
Before:

```
% atop -X -J PRG 1 | jq
{
      "pid": 514432,
      "name": "(php-fpm8.2)",
      "state": "E",
      "ruid": 69963,
      "rgid": 69963,
      "tgid": 514432,
      "nthr": 1,
      "st": "-E",
      "exitcode": 0,
      "btime": "1700730621",
      "cmdline": "(php-fpm: pool www                                          )",
      "ppid": 514430,
      "nthrrun": 0,
      "nthrslpi": 0,
      "nthrslpu": 0,
      "nthridle": 0,
      "euid": 0,
      "egid": 0,
      "elaps": "1299",
      "isproc": 1,
      "cid": "-"
    },
```

After:
```
    {
      "pid": 526057,
      "name": "(php-fpm8.2)",
      "state": "S",
      "ruid": 70019,
      "rgid": 70019,
      "tgid": 526057,
      "nthr": 1,
      "st": "-E",
      "exitcode": 0,
      "btime": "1700731393",
      "cmdline": "(php-fpm: master process (/etc/php-fpm/php-fpm.conf)        )",
      "ppid": 1,
      "nthrrun": 0,
      "nthrslpi": 1,
      "nthrslpu": 0,
      "nthridle": 0,
      "euid": 70019,
      "egid": 70019,
      "elaps": "0",
      "isproc": 1,
      "cid": "-",
      "cgroup": "/u000000096"
    },
```