### PR TITLE
add hpuse for per numa

### DIFF
--- a/deviate.c
+++ b/deviate.c
@@ -784,6 +784,7 @@ deviatsyst(struct sstat *cur, struct sstat *pre, struct sstat *dev,
 		dev->memnuma.numa[i].slabmem     = cur->memnuma.numa[i].slabmem;
 		dev->memnuma.numa[i].slabreclaim = cur->memnuma.numa[i].slabreclaim;
 		dev->memnuma.numa[i].tothp       = cur->memnuma.numa[i].tothp;
+		dev->memnuma.numa[i].freehp       = cur->memnuma.numa[i].freehp;
 		dev->memnuma.numa[i].frag        = cur->memnuma.numa[i].frag;
 	}
 

--- a/man/atop.1
+++ b/man/atop.1
@@ -1529,8 +1529,8 @@ the amount of free memory ('free'), the amount of memory for cached file data
 ('file'), modified cached file data ('dirty'), recently used memory ('activ'),
 less recently used memory ('inact'), memory being used for kernel mallocs
 ('slab'), the amount of slab memory that is reclaimable ('slrec'),
-shared memory including tmpfs ('shmem'), total huge pages ('hptot') and
-the fragmentation percentage ('frag').
+shared memory including tmpfs ('shmem'), total huge pages ('hptot'),
+used huge pages('hpuse'), and the fragmentation percentage ('frag').
 .PP
 .TP 5
 .B NUC

--- a/photosyst.c
+++ b/photosyst.c
@@ -1059,6 +1059,8 @@ photosyst(struct sstat *si)
 						si->memnuma.numa[j].slabreclaim = cnts[1]*1024/pagesize;
 					else if ( strcmp("HugePages_Total:", nam) == EQ)
 						si->memnuma.numa[j].tothp = cnts[1];
+					else if ( strcmp("HugePages_Free:", nam) == EQ)
+						si->memnuma.numa[j].freehp = cnts[1];
 				}
 				fclose(fp);
 			}

--- a/photosyst.h
+++ b/photosyst.h
@@ -123,6 +123,7 @@ struct	mempernuma {
 
 	count_t	shmem;		// tot shmem incl. tmpfs (pages) for this numa
 	count_t	tothp;		// total huge pages (huge pages) for this numa
+	count_t	freehp;		// total free pages (huge pages) for this numa
 };
 
 struct	memnuma {

--- a/showlinux.c
+++ b/showlinux.c
@@ -227,6 +227,7 @@ sys_printdef *memnumasyspdefs[] = {
 	&syspdef_NUMASHMEM,
 	&syspdef_NUMAFRAG,
 	&syspdef_NUMAHUPTOT,
+	&syspdef_NUMAHUPUSE,
         0
 };
 sys_printdef *cpunumasyspdefs[] = {
@@ -1005,7 +1006,8 @@ pricumproc(struct sstat *sstat, struct devtstat *devtstat,
 	                "NUMASLABRECLAIM:4 "
 	                "NUMASHMEM:4 "
 	                "NUMAFRAG:6 "
-	                "NUMAHUPTOT:3 ",
+	                "NUMAHUPTOT:4 "
+	                "NUMAHUPUSE:3 ",
 			memnumasyspdefs, "builtin memnumaline",
 			sstat, &extra);
                 }

--- a/showlinux.h
+++ b/showlinux.h
@@ -257,6 +257,7 @@ extern sys_printdef syspdef_NUMASHMEM;
 extern sys_printdef syspdef_NUMASLABRECLAIM;
 extern sys_printdef syspdef_NUMAFRAG;
 extern sys_printdef syspdef_NUMAHUPTOT;
+extern sys_printdef syspdef_NUMAHUPUSE;
 extern sys_printdef syspdef_NUMANUMCPU;
 extern sys_printdef syspdef_NUMACPUSYS;
 extern sys_printdef syspdef_NUMACPUUSER;

--- a/showsys.c
+++ b/showsys.c
@@ -1937,6 +1937,21 @@ sysprt_NUMAHUPTOT(struct sstat *sstat, extraparam *as, int badness, int *color)
 sys_printdef syspdef_NUMAHUPTOT = {"NUMAHUPTOT", sysprt_NUMAHUPTOT, sysval_HUPTOT};
 /*******************************************************************/
 static char *
+sysprt_NUMAHUPUSE(struct sstat *sstat, extraparam *as, int badness, int *color)
+{
+	static char buf[16]="hpuse  ";
+	if (sstat->mem.tothugepage == 0)
+		return NULL;
+
+	*color = -1;
+	val2memstr( (sstat->memnuma.numa[as->index].tothp - sstat->memnuma.numa[as->index].freehp)
+                                                  * sstat->mem.hugepagesz, buf+6, MBFORMAT, 0, 0);
+	return buf;
+}
+
+sys_printdef syspdef_NUMAHUPUSE = {"NUMAHUPUSE", sysprt_NUMAHUPUSE, sysval_HUPUSE};
+/*******************************************************************/
+static char *
 sysprt_NUMANUMCPU(struct sstat *sstat, extraparam *as, int badness, int *color) 
 {
         static char buf[16]="numcpu ";


### PR DESCRIPTION
In the system, MEM's `hptot` > `hpuse` , but the task failed to start due to the inability to allocate hugepages. Possibly due to insufficient hugepages on a certain numa node, so a new numa mem field `hpuse` is added to determine this situation.