### PR TITLE
set LDFLAGS with +=, not overwriting existing variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ PMPATH2  = /usr/lib64/pm-utils/sleep.d
 PMPATHD  = /usr/lib/systemd/system-sleep
 
 CFLAGS  += -O2 -I. -Wall $(shell pkg-config --cflags glib-2.0)  -Wno-stringop-truncation -Wmissing-prototypes -Wmissing-declarations -Wformat-security # -DNOPERFEVENT   # -DHTTPSTATS
-LDFLAGS  = $(shell pkg-config --libs glib-2.0)
+LDFLAGS += $(shell pkg-config --libs glib-2.0)
 OBJMOD0  = version.o
 OBJMOD1  = various.o  deviate.o   procdbase.o
 OBJMOD2  = acctproc.o photoproc.o photosyst.o  rawlog.o ifprop.o parseable.o


### PR DESCRIPTION
this allows the Debian build process to set hardening flags