### PR TITLE
atop[acct|gpu].service: Remove syslog.target

### DIFF
--- a/atopacct.service
+++ b/atopacct.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Atop process accounting daemon
 Documentation=man:atopacctd(8)
-After=syslog.target
 Before=atop.service
 
 [Service]

--- a/atopgpu.service
+++ b/atopgpu.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Atop GPU stats daemon
 Documentation=man:atopgpud(8)
-After=syslog.target
 Before=atop.service
 
 [Service]


### PR DESCRIPTION
Remove syslog.target from service files, this target hasn't existed for over a decade.

https://github.com/systemd/systemd/blob/6aa8d43ade72e24c9426e604f7fc4b7582b9db7c/NEWS#L72-L73

