### PR TITLE
Makefile: allow the user to pass additional CFLAGS and LDFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ PMPATH2  = /usr/lib64/pm-utils/sleep.d
 PMPATHD  = /usr/lib/systemd/system-sleep
 
 PKG_CONFIG ?= pkg-config
-CFLAGS  += -O2 -I. -Wall $(shell $(PKG_CONFIG) --cflags glib-2.0)  -Wno-stringop-truncation -Wmissing-prototypes -Wmissing-declarations -Wformat-security # -DNOPERFEVENT   # -DHTTPSTATS
-LDFLAGS += $(shell $(PKG_CONFIG) --libs glib-2.0)
+override CFLAGS  := -O2 -I. -Wall $(shell $(PKG_CONFIG) --cflags glib-2.0)  -Wno-stringop-truncation -Wmissing-prototypes -Wmissing-declarations -Wformat-security $(CFLAGS) # -DNOPERFEVENT   # -DHTTPSTATS
+override LDFLAGS := $(shell $(PKG_CONFIG) --libs glib-2.0) $(LDFLAGS)
 OBJMOD0  = version.o
 OBJMOD1  = various.o  deviate.o   procdbase.o
 OBJMOD2  = acctproc.o photoproc.o photosyst.o cgroups.o rawlog.o ifprop.o parseable.o


### PR DESCRIPTION
This is needed for some build systems. For example, Buildroot needs to disable optimizations on some CPU architectures.