### PR TITLE
/run/pacct_source abnormally large

### DIFF
--- a/atopacctd.c
+++ b/atopacctd.c
@@ -889,7 +889,7 @@ pass2shadow(int sfd, char *sbuf, int ssz)
 	{
 		syslog(LOG_ERR, "Unexpected write error to shadow file: %s\n",
  		     					strerror(errno));
-		exit(7);
+		cleanup_and_go = 129;
 	}
 
 	return ssz;


### PR DESCRIPTION
The main process of Atopacctd.service, namely /usr/sbin/atopacctd, exits abnormally due to a file-writing failure. Since acct() is not closed when the process exits, the kernel will continue writing to /run/pacct_source. The abnormal exit of the process leaves the file uncleaned, resulting in a gradual increase in its size. 