### PR TITLE
Fixed possible access out-of-bounds items array better check index before using

### DIFF
--- a/showlinux.c
+++ b/showlinux.c
@@ -642,7 +642,7 @@ make_sys_prints(sys_printpair *ar, int maxn, const char *pairs,
 
         makeargv(str, linename, items);
 
-        for(i=a=0; items[i].name && i<maxn-1; i++) 
+        for(i=a=0; i<maxn-1 && items[i].name; i++)
         {
                 const char *name=items[i].name;
                 int j;
@@ -736,7 +736,7 @@ make_detail_prints(detail_printpair *ar, int maxn, const char *pairs,
         makeargv(str, linename, items);
 
         int i;
-        for(i=0; items[i].name && i<maxn-1; ++i) 
+        for(i=0; i<maxn-1 && items[i].name; ++i)
         {
                 const char *name=items[i].name;
                 int j;


### PR DESCRIPTION
@Atoptool,
Clang found this place is also dangerous, it is better to protect yourself and swap places conditionals expressions to avoid going beyond boundaries array.