### PR TITLE
Removed excess checks before free()

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -1016,8 +1016,7 @@ engine(void)
 		if ((supportflags & NETATOPD) && (nprocexitnet > 0))
 			netatop_exiterase();
 
-		if (gp)
-			free(gp);
+		free(gp);
 
 		if (lastcmd == MRESET)	/* reset requested ? */
 		{

--- a/cgroups.c
+++ b/cgroups.c
@@ -849,8 +849,7 @@ cgwipe(struct cgchainer **first,  struct cgchainer **last,
 	{
 		cpn = cp->next;
 
-		if (cp->proclist)
-			free(cp->proclist);
+		free(cp->proclist);
 
 		free(cp->cstat);
 		free(cp);

--- a/deviate.c
+++ b/deviate.c
@@ -88,14 +88,11 @@ deviattask(struct tstat    *curtpres, unsigned long ntaskpres,
 	/*
  	** remove allocated lists of previous sample and initialize counters
 	*/
-	if (devtstat->taskall)
-		free(devtstat->taskall);
+	free(devtstat->taskall);
 
-	if (devtstat->procall)
-		free(devtstat->procall);
+	free(devtstat->procall);
 
-	if (devtstat->procactive)
-		free(devtstat->procactive);
+	free(devtstat->procactive);
 
 	memset(devtstat, 0, sizeof *devtstat);
 

--- a/gpucom.c
+++ b/gpucom.c
@@ -302,8 +302,7 @@ gpud_statresponse(int maxgpu, struct pergpu *ggs, struct gpupidstat **gps)
 	return pids;
 
     close_and_return:
-	if (buf)
-		free(buf);
+	free(buf);
 
 	close(actsock);
 	actsock = -1;

--- a/netatopif.c
+++ b/netatopif.c
@@ -149,8 +149,7 @@ netatop_probe(void)
 		{
 			(void) close(netexitfd);
 
-			if (nahp)
-				munmap(nahp, sizeof *nahp);
+			munmap(nahp, sizeof *nahp);
 
 			netexitfd = -1;
 			nahp = NULL;

--- a/showgeneric.c
+++ b/showgeneric.c
@@ -859,8 +859,7 @@ text_samp(time_t curtime, int nsecs,
 				** selection specified for tasks:
 				** create new (worst case) pointer list if needed
 				*/
-				if (sellist)	// remove previous list if needed
-					free(sellist);
+				free(sellist); // remove previous list if needed
 	
 				sellist = malloc(sizeof(struct tstat *) * ncurlist);
 	
@@ -940,8 +939,7 @@ text_samp(time_t curtime, int nsecs,
 					if (!tsklist || ntsk != ntotal ||
 								tdeviate != deviatonly)
 					{
-						if (tsklist)
-							free(tsklist);	// remove current
+						free(tsklist);	// remove current
 	
 						tsklist = malloc(sizeof(struct tstat *)
 									    * ntotal);
@@ -1072,8 +1070,7 @@ text_samp(time_t curtime, int nsecs,
 				** when a list has been created already that is
 				** not suitable, first remove it
 				*/
-				if (cgroupsort)
-					free(cgroupsort);
+				free(cgroupsort);
 
 				cgroupsort = cgsort(cgchainers, ncgroups, curorder);
 
@@ -1096,8 +1093,7 @@ text_samp(time_t curtime, int nsecs,
 				** when a selection list has been created
 				** already that is not suitable, first remove it
 				*/
-				if (cgroupsel)
-					free(cgroupsel);
+				free(cgroupsel);
 
 				/*
 				** create new merged list of cgroups and processes
@@ -2676,16 +2672,16 @@ text_samp(time_t curtime, int nsecs,
 	}
 
     free_and_return:
-	if (tpcumlist)  free(tpcumlist);
-	if (pcumlist)   free(pcumlist);
-	if (tucumlist)  free(tucumlist);
-	if (ucumlist)   free(ucumlist);
-	if (tccumlist)  free(tccumlist);
-	if (ccumlist)   free(ccumlist);
-	if (tsklist)    free(tsklist);
-	if (sellist)    free(sellist);
-	if (cgroupsort) free(cgroupsort);
-	if (cgroupsel)  free(cgroupsel);
+	free(tpcumlist);
+	free(pcumlist);
+	free(tucumlist);
+	free(ucumlist);
+	free(tccumlist);
+	free(ccumlist);
+	free(tsklist);
+	free(sellist);
+	free(cgroupsort);
+	free(cgroupsel);
 
 	return lastchar;
 }


### PR DESCRIPTION
@Atoptool,

More info: https://stackoverflow.com/questions/13818803/check-for-null-before-delete-in-c-good-practice

In C this became possible after C89, code is cleaner.

```
 C89: 4.10.3.2 The free function.

The free function causes the space pointed to by ptr to be deallocated, that is, made available for further allocation. If ptr is a null pointer, no action occurs.
```