### PR TITLE
Align stuctures for 64-bit platforms

### DIFF
--- a/atopsar.c
+++ b/atopsar.c
@@ -82,9 +82,9 @@ static char		*datemsg = "-------------------------- analysis "
 /*
 ** structure definition for print-functions
 */
-struct pridef { 
-	char    wanted;         /* selected option (boolean)              */
+struct pridef {
 	char    *cntcat;        /* used categories of counters            */
+	char    wanted;         /* selected option (boolean)              */
 	char    flag;           /* flag on command line                   */
 	void    (*prihead)(int, int, int);   /* print header of list      */
 	int     (*priline)(struct sstat *, struct tstat *, struct tstat **,

--- a/drawbar.c
+++ b/drawbar.c
@@ -162,8 +162,8 @@ static WINDOW 	*headwin, *midline, *colupper, *collower;
 #define	MAXHEIGHT	25	// maximum bar height in lines
 
 struct vertval {
-	int	barval;			// total value of bar
 	char	*barlab;		// bar label
+	int	barval;			// total value of bar
 	char	basecolor;		// bar color or fill color
 
 	char 	barmap[MAXHEIGHT];	// color map

--- a/showgeneric.h
+++ b/showgeneric.h
@@ -35,11 +35,11 @@
 
 
 struct syscap {
-	int	nrcpu;
 	count_t	availcpu;
 	count_t	availmem;
 	count_t	availdsk;
 	count_t	availnet;
+	int	nrcpu;
 	int	nrgpu;
 	count_t	availgpumem; 	// GPU memory in Kb!
 	int	nrmemnuma;

--- a/showlinux.h
+++ b/showlinux.h
@@ -50,11 +50,11 @@ typedef struct {
         int		noverflow;
         int		avgval;
         int		nsecs;
+        int		index;
         count_t		mstot;
         count_t		iotot;
-	struct perdsk	*perdsk;
-        int		index;
         count_t		cputot;
+        struct perdsk	*perdsk;
         count_t		pernumacputot;
         count_t		percputot;
 } extraparam;


### PR DESCRIPTION
@Atoptool,
This PR will decrease costs copying, moving, and creating object-structures only for common 64bit processors due to the 8-byte data alignment.

Smaller size structure or class, higher chance putting into CPU cache. Most processors are already 64 bit, so the change won't make it any worse.

## Info about technique:

https://hpc.rz.rptu.de/Tutorials/AVX/alignment.shtml

https://wr.informatik.uni-hamburg.de/_media/teaching/wintersemester_2013_2014/epc-14-haase-svenhendrik-alignmentinc-presentation.pdf

https://en.wikipedia.org/wiki/Data_structure_alignment

https://stackoverflow.com/a/20882083

https://zijishi.xyz/post/optimization-technique/learning-to-use-data-alignment/

## Affected structs:
- extraparam 120 -> 112 bytes
- vertval 136 -> 128 bytes
- pridef 48 -> 40 bytes
- syscap 64 -> 56 bytes