### PR TITLE
Fix memory-unsafe and buggy argv[0] string comparison

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -343,7 +343,7 @@ main(int argc, char *argv[])
 	else
 		p = argv[0];
 
-	if ( memcmp(p, "atopsar", 7) == 0)
+	if ( strcmp(p, "atopsar") == 0)
 		return atopsar(argc, argv);
 
 	/* 


### PR DESCRIPTION
memcmp assumes both its arguments have as many bytes as is specified, but argv[0] may not be at least 7 bytes long (including when run as atop, where it will have 5 bytes including the terminator). This can lead to buffer overreads, whether in the system memcmp implementation or in compiler-inlined versions (as is the case when compiling with LLVM, for example). Moreover, 7 was the incorrect count to be using anyway as it won't check that "atopsar" is terminated, so will return true if argv[0] merely has "atopsar" as a prefix.

Fix both of these by using strcmp instead.