### PR TITLE
command-line may contain a carriage return

### DIFF
--- a/photoproc.c
+++ b/photoproc.c
@@ -843,6 +843,7 @@ proccmd(struct tstat *curtask)
 				{
 				   case '\0':
 				   case '\n':
+				   case '\r':
 				   case '\t':
 					*pc = ' ';
 				}


### PR DESCRIPTION
We have some issue when /proc/[pid]/cmdline contains a carriage return (don't ask why). It messes up atop output, whether it is interactive or parsable. 

Let's convert it to space like the null-bytes, linefeed and tabs.

![atop_cr](https://github.com/user-attachments/assets/59f89138-21d0-4058-9521-94c371e9fecc)

https://github.com/user-attachments/assets/d3498bf8-f595-445e-b460-c896f684cf53

