### PR TITLE
atopgpud: fork before any thread action

### DIFF
--- a/atopgpud
+++ b/atopgpud
@@ -582,15 +582,16 @@ lg = logging.getLogger()		# root logger
 lg.addHandler(fh)
 lg.setLevel(loglevel)
 
-# -----------------------------
-# release parent process
-# (daemonize)
-# -----------------------------
-try:
-    if os.fork():
-        sys.exit(0)	# parent process exits; child continues...
-except Exception:
-    logging.error("Failed to fork child")
+if '-f' not in sys.argv:
+    # -----------------------------
+    # release parent process
+    # (daemonize)
+    # -----------------------------
+    try:
+        if os.fork():
+            sys.exit(0)	# parent process exits; child continues...
+    except Exception:
+        logging.error("Failed to fork child")
 
 # -----------------------------
 # load module pynvml


### PR DESCRIPTION
since python 3.12, os.fork now raise a DeprecationWarning, see https://docs.python.org/3/whatsnew/3.12.html#deprecated:

> /usr/bin/atopgpud:283: DeprecationWarning: This process (pid=64696)
> is multi-threaded, use of fork() may lead to deadlocks in the child.

so let's fork as early as possible, before any thread action (gpulock & "import pynvml").