### PR TITLE
Fix tmpfs calculation for memory bargraph

### DIFF
--- a/drawbar.c
+++ b/drawbar.c
@@ -2036,12 +2036,12 @@ drawmemory(struct perwindow *w, struct sstat *sstat, int nsecs,
 			  (sstat->mem.ltothugepage - sstat->mem.lfreehugepage)
 							* sstat->mem.lhugepagesz;
 							
-	shmrssreal	= (sstat->mem.shmrss * pagesize) - hugeused;	// in bytes!
+	shmrssreal	= (sstat->mem.shmrss * pagesize) - hugeused;
 
 	if (shmrssreal < 0)	// (partly) wrong assumption about static huge pages
 		shmrssreal = 0;
 
-	tmpfsmem	= (sstat->mem.shmem - sstat->mem.shmswp) * pagesize - shmrssreal / pagesize;
+	tmpfsmem	= (sstat->mem.shmem - sstat->mem.shmswp) * pagesize - shmrssreal;
 
 	// determine severity for pagescans, swapouts and oomkills
 	// 'n' - normal,


### PR DESCRIPTION
Revert "Bug solution: convert shmrssreal to pages before use"
This reverts commit 00d79f6636cde7742df29ca04596d6feb474c6c6.

Without the patch I see shmem 9.1G shmrss 8.2G in text mode, but bar graph mode shows tmpfs segment as big as sharedmem. The reverted commit definitely looks like a mistake. Didn't test with huge pages though.