### PR TITLE
atop: use safe_strcpy() for premature attention and safety

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -397,7 +397,7 @@ main(int argc, char *argv[])
 					{
 						if (strlen(argv[optind]) == 1)
 						{
-							strcpy(irawname, "/dev/stdin");
+							safe_strcpy(irawname, "/dev/stdin", sizeof irawname);
 							optind++;
 						}
 					}


### PR DESCRIPTION
@Atoptool,
This change will help you pay attention in the future if this buffer `/dev/stdin` and code associated with it are edited.