### PR TITLE
showlinux: replace strcpy to strncpy for premature attention and safety

### DIFF
--- a/showlinux.c
+++ b/showlinux.c
@@ -658,7 +658,8 @@ make_sys_prints(sys_printpair *ar, int maxn, const char *pairs,
         int		i, a, n=strlen(pairs);
         char		str[n+1];
 
-        strcpy(str, pairs);
+        strncpy(str, pairs, n);
+        str[n] = '\0';
 
         makeargv(str, linename, items);
 


### PR DESCRIPTION
This change will help contributors pay attention in the future if this buffer string sys_prints and code associated with it are changed