### PR TITLE
parseable: replace strcpy to strncpy for premature attention and safety

### DIFF
--- a/parseable.c
+++ b/parseable.c
@@ -1205,8 +1205,8 @@ spaceformat(char *istr, char *ostr)
 	if (!rmspaces)
 	{
 		*ostr = '(';
-		strcpy(ostr+1, istr);
-		strcat(ostr, ")");
+		strncpy(ostr+1, istr, PNAMLEN);
+		strncat(ostr, ")", 1);
 	}
 	// formatting with underscores without parenthesis required
 	else


### PR DESCRIPTION
This change will help you pay attention in the future if this buffer out string spaceformat and code associated with it are changed