### PR TITLE
Extend MAXIBNAME to 20

### DIFF
--- a/photosyst.h
+++ b/photosyst.h
@@ -41,7 +41,7 @@
 #define	MAXLLC		256
 
 #define	MAXDKNAM	32
-#define	MAXIBNAME	12
+#define	MAXIBNAME	20
 
 /************************************************************************/
 struct	memstat {


### PR DESCRIPTION
The IB device name may exceeds original 12 bytes, for example a RXE device: rxe_enp161s0np0 (16 bytes with null terminated) then atop will read the truncated path:
/sys/class/infiniband/rxe_enp161s/ports/1/rate

however the correct path is:
/sys/class/infiniband/rxe_enp161s0np0/ports/1/rate

So atop fails to get the real rate, and set rate field to 0. Commit 19e7bbec("Avoid divide by zero when InfiniBand rate is 0") fixed the bottom part of *using* rate, and this change fixes the top part of *collecting* rate.