### PR TITLE
Fix "failed to parse numa bitmap" on systems with more than 512 CPUs

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -187,7 +187,7 @@ static int	v6tab_entries = sizeof(v6tab)/sizeof(struct v6tab);
 
 // The following values are used to accumulate cpu statistics per numa.
 // The bitmask realization is from numactl
-#define CPUMASK_SZ (64 * 8)
+#define CPUMASK_SZ (64 * 64)
 
 #define bitsperlong (8 * sizeof(unsigned long))
 #define howmany(x,y) (((x)+((y)-1))/(y))


### PR DESCRIPTION
## Summary

- Increase `CPUMASK_SZ` from `(64 * 8)` (512) to `(64 * 64)` (4096) to match `MAXCPU` in `photosyst.h`
- On systems with more than 512 CPUs, `numa_parse_bitmap_v2()` exceeded the bitmask array bounds and returned `-1`, causing a fatal `"failed to parse numa bitmap"` error

## Root Cause

`CPUMASK_SZ` was hardcoded to 512 bits, but `/sys/devices/system/node/nodeX/cpumap` on a 768-CPU system contains 768 bits (24 x 32-bit hex groups). The parser merges adjacent 32-bit groups into 64-bit longs, requiring 12 longs, but the array only held 8 (`CPU_LONGS(512)`). This caused the bounds check `if (i >= CPU_LONGS(ncpus))` to fail.

## Test plan

- [x] Verified with unit test using actual 768-CPU cpumap data from a production system
- [x] Confirmed the old value (512) reproduces the failure
- [x] Confirmed the new value (4096) parses correctly and produces correct bitmask values
- [x] Verified backward compatibility with smaller systems (64, 128, 512 CPUs)

Fixes #372