### PR TITLE
Improved safety atop.daily

### DIFF
--- a/atop.daily
+++ b/atop.daily
@@ -5,62 +5,51 @@ LOGINTERVAL=600				# default interval in seconds
 LOGGENERATIONS=28			# default number of days
 LOGPATH=/var/log/atop                   # default log location
 
-mkdir -p "$LOGPATH"
+[ -d "$LOGPATH" ] || mkdir -p "$LOGPATH"
 
 # allow administrator to overrule the variables
 # defined above
 #
 DEFAULTSFILE=/etc/default/atop		# possibility to overrule vars
 
-if [ -e "$DEFAULTSFILE" ]
-then
-	. "$DEFAULTSFILE"
-
-	# validate overruled variables
-	# (LOGOPTS and LOGINTERVAL are implicitly by atop)
-	#
- 	case "$LOGGENERATIONS" in
-	    ''|*[!0-9]*)
-		echo non-numerical value for LOGGENERATIONS >&2
-		exit 1;;
-	esac
+if [ -e "$DEFAULTSFILE" ]; then
+    . "$DEFAULTSFILE"
+    case "$LOGGENERATIONS" in
+        ''|*[!0-9]*) echo "non-numerical value for LOGGENERATIONS" >&2; exit 1;;
+    esac
 fi
 
-CURDAY=`date +%Y%m%d`
+CURDAY=$(date +%Y%m%d)
 BINPATH=/usr/bin
 PIDFILE=/var/run/atop.pid
 
 # verify if atop still runs for daily logging
 #
-if [ -e "$PIDFILE" ] && ps -p `cat "$PIDFILE"` | grep 'atop$' > /dev/null
-then
-	kill -USR2 `cat "$PIDFILE"`       # final sample and terminate
-
-	CNT=0
-
-	while ps -p `cat "$PIDFILE"` > /dev/null
-	do
-		CNT=$((CNT + 1))
-
-		if [ $CNT -gt 5 ]
-		then
-			break;
-		fi
-
-		sleep 1
-	done
-
-	rm "$PIDFILE"
+if [ -e "$PIDFILE" ]; then
+    PID=$(cat "$PIDFILE")
+    case $PID in
+        ''|*[!0-9]*) echo "Invalid PID in $PIDFILE" >&2; exit 1;;
+    esac
+    if ps -p "$PID" | grep 'atop$' > /dev/null; then
+        kill -USR2 "$PID"
+        CNT=0
+        while ps -p "$PID" > /dev/null; do
+            CNT=$((CNT+1))
+            [ "$CNT" -gt 5 ] && break
+            sleep 1
+        done
+    fi
+    rm -f "$PIDFILE"
 fi
 
 # delete logfiles older than N days (configurable)
 # start a child shell that activates another child shell in
 # the background to avoid a zombie
 #
-( (sleep 3; find "$LOGPATH" -name 'atop_*' -mtime +"$LOGGENERATIONS" -exec rm {} \;)& )
+( (sleep 3; find "$LOGPATH" -name 'atop_*' -mtime +"$LOGGENERATIONS" -exec rm -- {} \;)& )
 
 # activate atop with an interval of S seconds (configurable),
 # replacing the current shell
 #
-echo $$ > $PIDFILE
-exec $BINPATH/atop $LOGOPTS -w "$LOGPATH"/atop_"$CURDAY" "$LOGINTERVAL" > "$LOGPATH/daily.log" 2>&1
+echo $$ > "$PIDFILE"
+exec "$BINPATH/atop" $LOGOPTS -w "$LOGPATH"/atop_"$CURDAY" "$LOGINTERVAL" > "$LOGPATH/daily.log" 2>&1


### PR DESCRIPTION
Reasons create this PR changes

- Substitution of variables without quotation marks
In shell scripts, $PIDFILE and $LOGPATH are sometimes used without quotes, which is dangerous for paths with spaces or special characters

- Executing external commands with substitution
The use of ps -p `'cat $PIDFILE'` and similar constructions (kill `'cat $PIDFILE'`) is dangerous if there is no verification of the contents of the PID file (for example, if the file is tampered with by an attacker)

- Without checking the expandable path, it potentially allows you to delete files outside the destination area if variables are substituted

- Before using the contents of the PIDFILE, make sure that it contains only numbers.

- Instead of rm {} use -- and quoting