### PR TITLE
Increase CMD column width to 15 characters for full thread names

### DIFF
--- a/showprocs.c
+++ b/showprocs.c
@@ -1630,20 +1630,20 @@ int compcmd(const void *, const void *, void *);
 char *
 procprt_CMD_a(struct tstat *curstat, int avgval, int nsecs)
 {
-        static char buf[15];
+        static char buf[16];
 
-        snprintf(buf, sizeof buf, "%-14.14s", curstat->gen.name);
+        snprintf(buf, sizeof buf, "%-15.15s", curstat->gen.name);
         return buf;
 }
 
 char *
 procprt_CMD_e(struct tstat *curstat, int avgval, int nsecs)
 {
-        static char buf[15]="<";
-        char        helpbuf[15];
+        static char buf[16]="<";
+        char        helpbuf[17];
 
-        snprintf(helpbuf, sizeof helpbuf, "<%.12s>",  curstat->gen.name);
-        snprintf(buf,     sizeof buf,     "%-14.14s", helpbuf);
+        snprintf(helpbuf, sizeof helpbuf, "<%.13s>",  curstat->gen.name);
+        snprintf(buf,     sizeof buf,     "%-15.15s", helpbuf);
         return buf;
 }
 
@@ -1657,7 +1657,7 @@ compcmd(const void *a, const void *b, void *dir)
 }
 
 detail_printdef procprt_CMD = 
-   {0, "CMD           ", "CMD", .ac.doactiveconverts = procprt_CMD_a, procprt_CMD_e, compcmd, 1, 14, 0};
+   {0, "CMD            ", "CMD", .ac.doactiveconverts = procprt_CMD_a, procprt_CMD_e, compcmd, 1, 15, 0};
 /***************************************************************/
 int compruid(const void *, const void *, void *);
 


### PR DESCRIPTION
## Summary

According to `pthread_setname_np(3)`, thread names can be up to 15 characters (16 bytes including the null terminator). The CMD column in atop was previously limited to 14 characters, which caused the last character of thread names to be truncated.

This change increases the CMD column width from 14 to 15 characters to display full thread names.

## Changes

- Increased buffer size in `procprt_CMD_a()` from 15 to 16 bytes
- Increased buffer size in `procprt_CMD_e()` from 15 to 16 bytes (and helpbuf from 15 to 17)
- Updated format strings from `%-14.14s` to `%-15.15s`
- Updated `procprt_CMD` struct: column header width and `width` field from 14 to 15

## Test Plan

- [x] Build passes without compilation errors
- [x] Code follows existing project style

Fixes #321
