### PR TITLE
fix(display): widen CMD column from 14 to 15 characters

### DIFF
--- a/showprocs.c
+++ b/showprocs.c
@@ -1630,20 +1630,20 @@ int compcmd(const void *, const void *, void *);
 char *
 procprt_CMD_a(struct tstat *curstat, int avgval, int nsecs)
 {
-        static char buf[15];
+        static char buf[16];
 
-        snprintf(buf, sizeof buf, "%-14.14s", curstat->gen.name);
+        snprintf(buf, sizeof buf, "%-15.15s", curstat->gen.name);
         return buf;
 }
 
 char *
 procprt_CMD_e(struct tstat *curstat, int avgval, int nsecs)
 {
-        static char buf[15]="<";
-        char        helpbuf[15];
+        static char buf[16]="<";
+        char        helpbuf[17];
 
-        snprintf(helpbuf, sizeof helpbuf, "<%.12s>",  curstat->gen.name);
-        snprintf(buf,     sizeof buf,     "%-14.14s", helpbuf);
+        snprintf(helpbuf, sizeof helpbuf, "<%.13s>",  curstat->gen.name);
+        snprintf(buf,     sizeof buf,     "%-15.15s", helpbuf);
         return buf;
 }
 
@@ -1657,7 +1657,7 @@ compcmd(const void *a, const void *b, void *dir)
 }
 
 detail_printdef procprt_CMD = 
-   {0, "CMD           ", "CMD", .ac.doactiveconverts = procprt_CMD_a, procprt_CMD_e, compcmd, 1, 14, 0};
+   {0, "CMD            ", "CMD", .ac.doactiveconverts = procprt_CMD_a, procprt_CMD_e, compcmd, 1, 15, 0};
 /***************************************************************/
 int compruid(const void *, const void *, void *);
 


### PR DESCRIPTION
## Summary
- Widen CMD column from 14 to 15 characters to display full thread names

## Changes
| File | Change |
|------|--------|
| `showprocs.c` | Increase CMD column width from 14 to 15 in `procprt_CMD_a`, `procprt_CMD_e`, and `detail_printdef` |

## Test Plan
- [x] Build succeeds without warnings (`make` with `-Wall`)
- [ ] Verify CMD column shows full 15-character thread names in running atop output

`pthread_setname_np` allows thread names up to 15 visible characters (16 including null terminator). The CMD column was only 14 characters wide, causing the last character to be stripped from thread names. This fix widens the column to accommodate the full name.

Fixes #321
