### PR TITLE
Remove dead code in val2memstr: MAXEBYTE8 equals LLONG_MAX

### DIFF
--- a/atop.h
+++ b/atop.h
@@ -45,8 +45,6 @@
 #define	PBFORMAT	9
 #define	PBFORMAT_INT	10
 #define	EBFORMAT	11
-#define	EBFORMAT_INT	12
-#define	OVFORMAT	13
 
 typedef	long long	count_t;
 

--- a/various.c
+++ b/various.c
@@ -522,8 +522,6 @@ val2Hzstr(count_t value, char *strvalue)
 #define	MAXTBYTE9	(ONETBYTE*9LL)
 #define	MAXPBYTE 	(ONEPBYTE*999LL)
 #define	MAXPBYTE9	(ONEPBYTE*9LL)
-#define	MAXEBYTE 	(ONEEBYTE*999LL)
-#define	MAXEBYTE8	(ONEEBYTE*7LL+(ONEEBYTE-1))
 
 char *
 val2memstr(count_t value, char *strvalue, int pformat, int avgval, int nsecs)
@@ -586,10 +584,7 @@ val2memstr(count_t value, char *strvalue, int pformat, int avgval, int nsecs)
 		                                        if (verifyval <= MAXPBYTE)    /* pbytes 10-999 ? */
 		                                            aformat = PBFORMAT_INT;
 		                                        else
-		                                            if (verifyval <= MAXEBYTE8)    /* ebytes 1-8 ? */
-		                                                aformat = EBFORMAT;
-		                                            else
-		                                                aformat = OVFORMAT;    /* max long long */
+		                                            aformat = EBFORMAT;
 	} else 
 	/*
 	** printed value per interval (normal mode) 


### PR DESCRIPTION
MAXEBYTE8 is defined as (ONEEBYTE*7 + (ONEEBYTE-1)) which evaluates to 9223372036854775807 — exactly LLONG_MAX.  Since count_t is signed long long, the check "verifyval <= MAXEBYTE8" is always true, making the OVFORMAT branch unreachable dead code.

Simplify: anything past MAXPBYTE is unconditionally EBFORMAT.  Remove the unused MAXEBYTE8, MAXEBYTE, EBFORMAT_INT and OVFORMAT symbols.

Found by Coverity Scan (CID 504429, CID 504430).