### PR TITLE
netatop: use const ptr struct for micro-op and readability

### DIFF
--- a/atop.h
+++ b/atop.h
@@ -238,7 +238,7 @@ void		netatop_gettask(pid_t, char, struct tstat *);
 unsigned int	netatop_exitstore(void);
 void		netatop_exiterase(void);
 void		netatop_exithash(char);
-void		netatop_exitfind(unsigned long, struct tstat *, struct tstat *);
+void		netatop_exitfind(unsigned long, struct tstat *, const struct tstat *);
 
 void		netatop_bpf_ipopen(void);
 void		netatop_bpf_probe(void);

--- a/netatopbpfif.c
+++ b/netatopbpfif.c
@@ -49,8 +49,8 @@
 
 static int		netsock   = -1;
 
-static void	fill_networkcnt(struct tstat *, struct tstat *,
-        	                struct taskcount *);
+static void	fill_networkcnt(struct tstat *, const struct tstat *,
+        	                const struct taskcount *);
 void my_handler(int);
 
 int len;
@@ -154,7 +154,7 @@ netatop_bpf_gettask()
 void
 netatop_bpf_exitfind(unsigned long key, struct tstat *dev, struct tstat *pre)
 {
-	struct taskcount *tc = g_hash_table_lookup(ghash_net, &key);
+	const struct taskcount *tc = g_hash_table_lookup(ghash_net, &key);
 	/*
 	** correct PID found
 	*/
@@ -173,7 +173,7 @@ netatop_bpf_exitfind(unsigned long key, struct tstat *dev, struct tstat *pre)
 }
 
 static void
-fill_networkcnt(struct tstat *dev, struct tstat *pre, struct taskcount *tc)
+fill_networkcnt(struct tstat *dev, const struct tstat *pre, const struct taskcount *tc)
 {
 	dev->net.tcpsnd	= tc->tcpsndpacks - pre->net.tcpsnd;
 	dev->net.tcpssz	= tc->tcpsndbytes - pre->net.tcpssz;

--- a/netatopif.c
+++ b/netatopif.c
@@ -76,8 +76,8 @@ static struct exitstore *exitall;
 static int		 exitnum;
 static char		 exithash;
 
-static void	fill_networkcnt(struct tstat *, struct tstat *,
-        	                struct exitstore *);
+static void	fill_networkcnt(struct tstat *, const struct tstat *,
+        	                const struct exitstore *);
 
 /*
 ** open a raw socket to the IP layer (root privs required)
@@ -464,7 +464,7 @@ netatop_exithash(char hashtype)
 ** update counters in tstat struct
 */
 void
-netatop_exitfind(unsigned long key, struct tstat *dev, struct tstat *pre)
+netatop_exitfind(unsigned long key, struct tstat *dev, const struct tstat *pre)
 {
 	int 			h = HASHCALC(key);
 	struct exitstore	*esp;
@@ -524,7 +524,7 @@ netatop_exitfind(unsigned long key, struct tstat *dev, struct tstat *pre)
 }
 
 static void
-fill_networkcnt(struct tstat *dev, struct tstat *pre, struct exitstore *esp)
+fill_networkcnt(struct tstat *dev, const struct tstat *pre, const struct exitstore *esp)
 {
 	dev->net.tcpsnd	= esp->npt.tc.tcpsndpacks - pre->net.tcpsnd;
 	dev->net.tcpssz	= esp->npt.tc.tcpsndbytes - pre->net.tcpssz;

--- a/photoproc.c
+++ b/photoproc.c
@@ -219,7 +219,7 @@ photoproc(struct tstat *tasklist, int maxtask)
                 	procwchan(curtask);
 
 		if (supportflags & NETATOPBPF) {
-			struct taskcount *tc = g_hash_table_lookup(ghash_net, &(curtask->gen.tgid));
+			const struct taskcount *tc = g_hash_table_lookup(ghash_net, &(curtask->gen.tgid));
 			if (tc) {
 				// printf("%d %d %d %d %d\n",curtask->gen.tgid, tc->tcpsndpacks,  tc->tcprcvpacks, tc->udpsndpacks, tc->udprcvpacks);
 				curtask->net.tcpsnd = tc->tcpsndpacks;


### PR DESCRIPTION
Minor change use const pointer for code readability and better codegeneration by compiler (stack params function).

@Atoptool,
If you are interested in how assembly code on -O3 is micro-optimized in gcc, I can throw off asm listing images before and after calling fill_networkcnt() function. Example in netatop_bpf_exitfind()