### PR TITLE
photosyst: fix read uninit dist if bypass fgets() MISRA C:2023 9.1

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -2698,7 +2698,7 @@ void
 realnuma_support(void)
 {
 	FILE		*fp;
-	int		i, total, nr=0, dist[10];
+	int		i, total, nr=0, dist[10]={0};
 	char		linebuf[1024];
 
 	if ( (fp = fopen(NUMADISTANCE0, "r")) == NULL)


### PR DESCRIPTION
@Atoptool, for security reasons, I would merge this urgently, there is no CVE ID for this issue yet, I have not checked whether exploitation of the vulnerability is possible.

9.1 The value of an object with an automatic storage time should not be read before it has been set.

Reference: https://www.mathworks.com/help/bugfinder/ref/misrac2023rule9.1.html