### PR TITLE
photosyst: prevent buffer overflow name only 64 length

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -1090,7 +1090,7 @@ photosyst(struct sstat *si)
 				while ( fgets(linebuf, sizeof(linebuf), fp) != NULL)
 				{
 					nr = sscanf(&linebuf[5],
-						"%lld %s %lld\n",
+						"%lld %63s %lld\n",
 						&cnts[0], nam, &cnts[1]);
 
 					if (cnts[0] != j)


### PR DESCRIPTION
@Atoptool, This is also a useful PR change that limits the buffer size for sscanf in advance.
'nam' is a char array of size 64. The sscanf format string "%s" maybe to be changed to "%63s" to prevent a buffer overflow.