### PR TITLE
photosyst: fix incorrect format size fscanf (count_t is long long)

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -2670,7 +2670,7 @@ get_ksm(struct sstat *si)
 
 	if ((fp=fopen("/sys/kernel/mm/ksm/pages_sharing", "r")) != 0)
 	{
-		if (fscanf(fp, "%llu", &(si->mem.ksmsharing)) != 1)
+		if (fscanf(fp, "%lld", &(si->mem.ksmsharing)) != 1)
 			si->mem.ksmsharing = 0;
 
 		fclose(fp);
@@ -2678,7 +2678,7 @@ get_ksm(struct sstat *si)
 
 	if ((fp=fopen("/sys/kernel/mm/ksm/pages_shared", "r")) != 0)
 	{
-		if (fscanf(fp, "%llu", &(si->mem.ksmshared)) != 1)
+		if (fscanf(fp, "%lld", &(si->mem.ksmshared)) != 1)
 			si->mem.ksmshared = 0;
 
 		fclose(fp);


### PR DESCRIPTION
ksmsharing it count_t, count_t it `long long` in atop.h

https://github.com/Atoptool/atop/blob/d19cc1df0717c88fe9c421ce3d80be74c47677ee/photosyst.h#L79-L85

https://github.com/Atoptool/atop/blob/d19cc1df0717c88fe9c421ce3d80be74c47677ee/atop.h#L50-L52