### PR TITLE
photosyst: fix forgetten limit 15 size for all strings sscanf

### DIFF
--- a/photosyst.c
+++ b/photosyst.c
@@ -1452,7 +1452,7 @@ photosyst(struct sstat *si)
 		while ( fgets(linebuf, sizeof(linebuf), fp) != NULL)
 		{
 			nr = sscanf(linebuf,
-				"%15s %*s %*d %s %lld %*s %*d %*s %*d %s %lld\n",
+				"%15s %*s %*d %15s %lld %*s %*d %*s %*d %15s %lld\n",
 				nam, udpmem, &cnts[0], tcpmem, &cnts[1]);
 
 			if ( strcmp("TCP:", nam) == 0)


### PR DESCRIPTION
@Atoptool, please tell me, is it a typo? That the limit is made on only one %s parameter? shouldn't the 16 byte limit apply to all char arrays?