### PR TITLE
readrc does not handle if file cannot be opened and fp NULL goes to fgets()

### DIFF
--- a/atop.c
+++ b/atop.c
@@ -1188,6 +1188,10 @@ readrc(char *path, int syslevel)
 		char	linebuf[256], tagname[20], tagvalue[256];
 
 		fp = fopen(path, "r");
+		if (fp == NULL) {
+			fprintf(stderr, "Error: Could not open file %s\n", path);
+			return;
+		}
 
 		while ( fgets(linebuf, sizeof linebuf, fp) )
 		{


### PR DESCRIPTION
@Atoptool apparently there was a typo and forgot to check for a NULL pointer.
Attackers who break behavior opensource software can delete the file in order to follow an unspecified code execution path.