### PR TITLE
Add modern method get boottime modern Linux kernel

### DIFF
--- a/various.c
+++ b/various.c
@@ -757,27 +757,40 @@ getboot(void)
 static unsigned long long
 getbootlinux(long hertz)
 {
-	int    		 	cpid;
-	char  	  		tmpbuf[1280];
-	FILE    		*fp;
-	unsigned long 		startticks;
+	FILE			*fp;
+	char			linebuf[256];
+	unsigned long long	btime = 0;
+
+	if ((fp = fopen("/proc/stat", "r"))) {
+		while (fgets(linebuf, sizeof(linebuf), fp)) {
+			if (strncmp(linebuf, "btime ", 6) == 0) {
+				btime = atoll(linebuf + 6);
+				break;
+			}
+		}
+		fclose(fp);
+	}
+
+	if (btime)
+		return btime * hertz;
+
+	/*
+	** fallback for old kernels: dirty hack to get the boottime,
+	** since some Linux 2.6 kernels do not return a proper
+	** boottime-value with the times() system call   :-(
+	*/
+	int			cpid;
+	char			tmpbuf[1280];
+	unsigned long		startticks;
 	unsigned long long	bootjiffies = 0;
 	struct timespec		ts;
 
-	/*
-	** dirty hack to get the boottime, since the
-	** Linux 2.6 kernel (2.6.5) does not return a proper
-	** boottime-value with the times() system call   :-(
-	*/
-	if ( (cpid = fork()) == 0 )
-	{
+	if ((cpid = fork()) == 0) {
 		/*
 		** child just waiting to be killed by parent
 		*/
 		pause();
-	}
-	else
-	{
+	} else if (cpid > 0) {
 		/*
 		** parent determines start-time (in jiffies since boot) 
 		** of the child and calculates the boottime in jiffies


### PR DESCRIPTION
The old method is left in case /proc/stat doesn't work, but modern kernel advises against using this hack as it causes an expensive `fork()` system interrupt.

The fork() call requires the kernel to create a complete copy of the process's address space (using the Copy-on-Write mechanism), allocate new data structures (PIDs, descriptors), initialize page tables, etc. This is a heavy operation that consumes CPU and memory resources.[1][2]

References:
- [1] https://blog.codingconfessions.com/p/virtual-memory
- [2] https://www.cs.tufts.edu/comp/21/notes/processes/processes_c.html
- https://www.linuxhowtos.org/System/procstat.htm
- https://man7.org/linux/man-pages/man5/proc_stat.5.html