### PR TITLE
Fix MSan and UBSan Clang sanitizers issues

### DIFF
--- a/cgroups.c
+++ b/cgroups.c
@@ -148,7 +148,7 @@ cgroupv2support(void)
 	{
 		while (fgets(line, sizeof line, fp))
 		{
-			if (memcmp(line, "0::", 3) == 0) // equal?
+			if (strncmp(line, "0::", 3) == 0) // equal?
 			{
 				supportflags |= CGROUPV2;
 				break;
@@ -541,14 +541,14 @@ getmetrics(struct cstat *csp)
 	{
 		while (fgets(line, sizeof line, fp) && cnt < 2)
 		{
-			if (memcmp(line, "user_usec ", 10) == 0)
+			if (strncmp(line, "user_usec ", 10) == 0)
 			{
 				sscanf(line, "user_usec %lld", &(csp->cpu.utime));
 				cnt++;
 				continue;
 			}
 
-			if (memcmp(line, "system_usec ", 12) == 0)
+			if (strncmp(line, "system_usec ", 12) == 0)
 			{
 				sscanf(line, "system_usec %lld", &(csp->cpu.stime));
 				cnt++;
@@ -584,7 +584,7 @@ getmetrics(struct cstat *csp)
 	{
 		while (fgets(line, sizeof line, fp) && cnt < 4)
 		{
-			if (memcmp(line, "anon ", 5) == 0)
+			if (strncmp(line, "anon ", 5) == 0)
 			{
 				sscanf(line, "anon %lld", &(csp->mem.anon));
 				csp->mem.anon /= pagesize;
@@ -592,7 +592,7 @@ getmetrics(struct cstat *csp)
 				continue;
 			}
 
-			if (memcmp(line, "file ", 5) == 0)
+			if (strncmp(line, "file ", 5) == 0)
 			{
 				sscanf(line, "file %lld", &(csp->mem.file));
 				csp->mem.file /= pagesize;
@@ -600,7 +600,7 @@ getmetrics(struct cstat *csp)
 				continue;
 			}
 
-			if (memcmp(line, "kernel ", 7) == 0)
+			if (strncmp(line, "kernel ", 7) == 0)
 			{
 				sscanf(line, "kernel %lld", &(csp->mem.kernel));
 				csp->mem.kernel /= pagesize;
@@ -608,7 +608,7 @@ getmetrics(struct cstat *csp)
 				continue;
 			}
 
-			if (memcmp(line, "shmem ", 6) == 0)
+			if (strncmp(line, "shmem ", 6) == 0)
 			{
 				sscanf(line, "shmem %lld", &(csp->mem.shmem));
 				csp->mem.shmem /= pagesize;

--- a/photoproc.c
+++ b/photoproc.c
@@ -621,26 +621,26 @@ procstatus(struct tstat *curtask)
 
 	while (fgets(line, sizeof line, fp))
 	{
-		if (memcmp(line, "Tgid:", 5) ==0)
+		if (strncmp(line, "Tgid:", 5) ==0)
 		{
 			sscanf(line, "Tgid: %d", &(curtask->gen.tgid));
 			continue;
 		}
 
-		if (memcmp(line, "Pid:", 4) ==0)
+		if (strncmp(line, "Pid:", 4) ==0)
 		{
 			sscanf(line, "Pid: %d", &(curtask->gen.pid));
 			continue;
 		}
 
-		if (memcmp(line, "SleepAVG:", 9)==0)
+		if (strncmp(line, "SleepAVG:", 9)==0)
 		{
 			sscanf(line, "SleepAVG: %d%%",
 				&(curtask->cpu.sleepavg));
 			continue;
 		}
 
-		if (memcmp(line, "Uid:", 4)==0)
+		if (strncmp(line, "Uid:", 4)==0)
 		{
 			sscanf(line, "Uid: %d %d %d %d",
 				&(curtask->gen.ruid), &(curtask->gen.euid),
@@ -648,7 +648,7 @@ procstatus(struct tstat *curtask)
 			continue;
 		}
 
-		if (memcmp(line, "Gid:", 4)==0)
+		if (strncmp(line, "Gid:", 4)==0)
 		{
 			sscanf(line, "Gid: %d %d %d %d",
 				&(curtask->gen.rgid), &(curtask->gen.egid),
@@ -656,67 +656,67 @@ procstatus(struct tstat *curtask)
 			continue;
 		}
 
-		if (memcmp(line, "envID:", 6) ==0)
+		if (strncmp(line, "envID:", 6) ==0)
 		{
 			sscanf(line, "envID: %d", &(curtask->gen.ctid));
 			continue;
 		}
 
-		if (memcmp(line, "VPid:", 5) ==0)
+		if (strncmp(line, "VPid:", 5) ==0)
 		{
 			sscanf(line, "VPid: %d", &(curtask->gen.vpid));
 			continue;
 		}
 
-		if (memcmp(line, "Threads:", 8)==0)
+		if (strncmp(line, "Threads:", 8)==0)
 		{
 			sscanf(line, "Threads: %d", &(curtask->gen.nthr));
 			continue;
 		}
 
-		if (memcmp(line, "VmData:", 7)==0)
+		if (strncmp(line, "VmData:", 7)==0)
 		{
 			sscanf(line, "VmData: %lld", &(curtask->mem.vdata));
 			continue;
 		}
 
-		if (memcmp(line, "VmStk:", 6)==0)
+		if (strncmp(line, "VmStk:", 6)==0)
 		{
 			sscanf(line, "VmStk: %lld", &(curtask->mem.vstack));
 			continue;
 		}
 
-		if (memcmp(line, "VmExe:", 6)==0)
+		if (strncmp(line, "VmExe:", 6)==0)
 		{
 			sscanf(line, "VmExe: %lld", &(curtask->mem.vexec));
 			continue;
 		}
 
-		if (memcmp(line, "VmLib:", 6)==0)
+		if (strncmp(line, "VmLib:", 6)==0)
 		{
 			sscanf(line, "VmLib: %lld", &(curtask->mem.vlibs));
 			continue;
 		}
 
-		if (memcmp(line, "VmSwap:", 7)==0)
+		if (strncmp(line, "VmSwap:", 7)==0)
 		{
 			sscanf(line, "VmSwap: %lld", &(curtask->mem.vswap));
 			continue;
 		}
 
-		if (memcmp(line, "VmLck:", 6)==0)
+		if (strncmp(line, "VmLck:", 6)==0)
 		{
 			sscanf(line, "VmLck: %lld", &(curtask->mem.vlock));
 			continue;
 		}
 
-		if (memcmp(line, "voluntary_ctxt_switches:", 24)==0)
+		if (strncmp(line, "voluntary_ctxt_switches:", 24)==0)
 		{
 			sscanf(line, "voluntary_ctxt_switches: %lld", &(curtask->cpu.nvcsw));
 			continue;
 		}
 
-		if (memcmp(line, "nonvoluntary_ctxt_switches:", 27)==0)
+		if (strncmp(line, "nonvoluntary_ctxt_switches:", 27)==0)
 		{
 			sscanf(line, "nonvoluntary_ctxt_switches: %lld", &(curtask->cpu.nivcsw));
 			continue;
@@ -748,7 +748,7 @@ procio(struct tstat *curtask)
 		{
 			while (fgets(line, sizeof line, fp))
 			{
-				if (memcmp(line, IO_READ,
+				if (strncmp(line, IO_READ,
 						sizeof IO_READ -1) == 0)
 				{
 					sscanf(line, "%*s %llu", &dskrsz);
@@ -756,7 +756,7 @@ procio(struct tstat *curtask)
 					continue;
 				}
 
-				if (memcmp(line, IO_WRITE,
+				if (strncmp(line, IO_WRITE,
 						sizeof IO_WRITE -1) == 0)
 				{
 					sscanf(line, "%*s %llu", &dskwsz);
@@ -764,7 +764,7 @@ procio(struct tstat *curtask)
 					continue;
 				}
 
-				if (memcmp(line, IO_CWRITE,
+				if (strncmp(line, IO_CWRITE,
 						sizeof IO_CWRITE -1) == 0)
 				{
 					sscanf(line, "%*s %llu", &dskcwsz);
@@ -989,7 +989,7 @@ procsmaps(struct tstat *curtask)
 
 		while (fgets(line, sizeof line, fp))
 		{
-			if (memcmp(line, "Pss:", 4) != 0)
+			if (strncmp(line, "Pss:", 4) != 0)
 				continue;
 
 			// PSS line found to be accumulated

--- a/photosyst.c
+++ b/photosyst.c
@@ -579,10 +579,10 @@ photosyst(struct sstat *si)
 
 		        while ( fgets(linebuf, sizeof(linebuf), fp) != NULL)
                         {
-                                if (memcmp(linebuf, "processor", 9)== EQ)
+                                if (strncmp(linebuf, "processor", 9)== EQ)
 					sscanf(linebuf, "%*s %*s %d", &cpuno);
 
-                                if (memcmp(linebuf, "cpu MHz", 7) == EQ)
+                                if (strncmp(linebuf, "cpu MHz", 7) == EQ)
 				{
                                         if (cpuno >= 0 && cpuno < si->cpu.maxcpu)
 					{
@@ -679,7 +679,7 @@ photosyst(struct sstat *si)
 			}
 
 			// more counters might start with "allocstall"
-			if ( memcmp("allocstall", nam, 10) == EQ)
+			if ( strncmp("allocstall", nam, 10) == EQ)
 			{
 				si->mem.allocstall += cnts[0];
 				continue;
@@ -1788,7 +1788,7 @@ photosyst(struct sstat *si)
 
 	if ( (fp = fopen("self/mountstats", "r")) != NULL)
 	{
-		char 	mountdev[128], fstype[32], label[32];
+		char 	mountdev[128], fstype[32] = "", label[32];
                 count_t	cnt[8];
 
 		i = 0;
@@ -1803,7 +1803,7 @@ photosyst(struct sstat *si)
 				continue;
 			}
 
-			if (memcmp(fstype, "nfs", 3) != 0)
+			if (strncmp(fstype, "nfs", 3) != 0)
 				continue;
 
 			// this is line with NFS client stats

--- a/showgeneric.c
+++ b/showgeneric.c
@@ -256,7 +256,7 @@ generic_samp(time_t curtime, int nsecs,
 ** print the deviation-counters on process level, cgroups level and
 ** system level in text mode
 */
-#define	SORTHASH(x)	((x.ascdesc << 8)|(x.sortcolumn ? x.sortcolumn : x.showresource|0x80))
+#define	SORTHASH(x)	(((unsigned char)(x.ascdesc) << 8)|(x.sortcolumn ? x.sortcolumn : x.showresource|0x80))
 
 static char
 text_samp(time_t curtime, int nsecs,


### PR DESCRIPTION
@Atoptool this changes affected security issues use sanitizers from LLVM team

My Clang sanitizers build logs:
[asan_build.log](https://github.com/user-attachments/files/30947641/asan_build.log)
[ubsan_build.log](https://github.com/user-attachments/files/30947642/ubsan_build.log)
[tsan_build.log](https://github.com/user-attachments/files/30947643/tsan_build.log)
[msan_build.log](https://github.com/user-attachments/files/30947644/msan_build.log)

Atop run logs with sanitz:
[msan_run.log](https://github.com/user-attachments/files/30947622/msan_run.log)
[ubsan_run.log](https://github.com/user-attachments/files/30947624/ubsan_run.log)

## Shorten desc from my commit

MSAN: revealed read  uninit memory. This happens when comparing strs in file parsing functions (when memcmp function checks more bytes than were actually read from file, because it does not stop at zero byte). An uninit fstype variable was also found.

UBSAN: found undefined behavior in C when performing a bitwise left shift of a negative value (-1) in the SORTHASH macro

## Very detailed desc PR changes in commit

### MemorySanitizer (MSAN) Fixes
MSAN detected use-of-uninitialized-value errors in photosyst.c and photoproc.c. The root cause is comparing buffers using memcmp without ensuring the buffer is fully initialized up to the comparison length, or using uninitialized stack variables.

Initialize fstype: At line 1791, fstype is left uninitialized. If the line read from mountstats does not match the sscanf format, fstype remains uninitialized, but it is subsequently used in memcmp(fstype, "nfs", 3). We will initialize it: char fstype[32] = "";
Replace memcmp with strncmp: In lines 582, 585, and 682, memcmp is used for string prefix matching on lines read via fgets. If a line is shorter than the searched prefix, memcmp reads uninitialized bytes past the null terminator. Using strncmp prevents this.

Replace memcmp with strncmp: There are over 20 instances where memcmp(line, "prefix", length) is used to parse /proc status lines. We will replace all these instances with strncmp to prevent reading uninitialized bytes when lines are short.

Replace memcmp with strncmp: Similar to photoproc.c, we will replace prefix-matching memcmp calls with strncmp to avoid MSAN errors.

### UndefinedBehaviorSanitizer (UBSAN) Fixes
UBSAN detected runtime error: left shift of negative value -1 in showgeneric.c.

Fix SORTHASH Macro: At line 259, the macro SORTHASH(x) performs x.ascdesc << 8. Since ascdesc is a signed char which can be -1, shifting it left is undefined behavior in C. We will cast it to unsigned char before shifting: ((unsigned char)(x.ascdesc) << 8).
